### PR TITLE
Move entry HTML into Vite root and bundle theme CSS

### DIFF
--- a/highland-cow-farm/index.html
+++ b/highland-cow-farm/index.html
@@ -4,8 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Highland Cow Farm Adventure</title>
-  <link rel="stylesheet" href="/src/styles/theme.css" />
-  </head>
+</head>
 <body>
   <main id="app" aria-live="polite">
     <section class="screen active" data-screen="title" aria-labelledby="title-heading">
@@ -194,6 +193,6 @@
     </section>
   </main>
 
-    <script type="module" src="/src/main.ts"></script>
+  <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/highland-cow-farm/src/main.ts
+++ b/highland-cow-farm/src/main.ts
@@ -1,3 +1,5 @@
+import './styles/theme.css';
+
 import { registerScreen, showScreen } from './core/screens';
 import { initAudio, setEnabled, setVolumes, ensureAmbience, stopAmbience } from './core/audio';
 import * as State from './core/state';


### PR DESCRIPTION
## Summary
- move the app entry markup from `public/index.html` into a root-level `index.html` so Vite processes it
- import the shared theme stylesheet from `src/main.ts` so it is bundled with the production build

## Testing
- `npm run build` *(fails: vite missing because dependencies cannot be installed in this environment)*
- `npm run preview` *(fails: vite missing because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4a0e71948321bada898c69a50f61