### PR TITLE
Refine cow anatomy rendering

### DIFF
--- a/highland-cow-farm/src/data/accessories.ts
+++ b/highland-cow-farm/src/data/accessories.ts
@@ -1,50 +1,82 @@
 import type { Cow } from '../types';
+import type { AccessoryRenderMeta, CowVisualOptions } from '../game/cowVisuals';
+
+const fmt = (value: number): string => (Number.isFinite(value) ? Number(value.toFixed(3)).toString() : '0');
+
+function withClip(ctx: CanvasRenderingContext2D, meta: AccessoryRenderMeta | undefined, draw: () => void) {
+  ctx.save();
+  if (meta?.clipAboveHead && meta.clipAboveHead.height > 0) {
+    ctx.beginPath();
+    ctx.rect(-220, meta.clipAboveHead.y, 440, meta.clipAboveHead.height);
+    ctx.clip();
+  }
+  draw();
+  ctx.restore();
+}
+
+function clipAttribute(meta: AccessoryRenderMeta | undefined): string {
+  return meta?.clipPathId ? ` clip-path="url(#${meta.clipPathId})"` : '';
+}
 
 export interface AccessoryEntry {
   icon: string;
   description: string;
-  svg?: (cow?: Cow) => string;
-  draw?: (ctx: CanvasRenderingContext2D, cow?: Cow, meta?: any) => void;
+  svg?: (cow?: Cow, meta?: AccessoryRenderMeta) => string;
+  draw?: (ctx: CanvasRenderingContext2D, cow?: Cow, meta?: AccessoryRenderMeta & CowVisualOptions) => void;
 }
 
 export const AccessoryLibrary: Record<string, AccessoryEntry> = {
   'Pastel Bow': {
     icon: '🎀',
     description: 'A soft ribbon tied neatly near the fringe.',
-    svg: () => `
-          <g class="acc acc-bow" transform="translate(-20,-18)">
+    svg: (_cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const x = anatomy ? -anatomy.head.width * 0.36 : -20;
+      const y = anatomy ? anatomy.horns.baseY + anatomy.horns.thickness * 1.1 : -18;
+      return `
+          <g class="acc acc-bow"${clipAttribute(meta)} transform="translate(${fmt(x)} ${fmt(y)})">
             <ellipse cx="-6" cy="-2" rx="6" ry="8" fill="#f7c1d8" />
             <ellipse cx="6" cy="-2" rx="6" ry="8" fill="#f7c1d8" />
             <circle cx="0" cy="-2" r="3.4" fill="#f38aad" />
-          </g>`,
-    draw: ctx => {
-      ctx.save();
-      ctx.translate(-20, -18);
-      ctx.fillStyle = '#f7c1d8';
-      ctx.beginPath();
-      ctx.ellipse(-6, -2, 6, 8, 0, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.beginPath();
-      ctx.ellipse(6, -2, 6, 8, 0, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.fillStyle = '#f38aad';
-      ctx.beginPath();
-      ctx.arc(0, -2, 3.4, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.restore();
+          </g>`;
+    },
+    draw: (ctx, _cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const x = anatomy ? -anatomy.head.width * 0.36 : -20;
+      const y = anatomy ? anatomy.horns.baseY + anatomy.horns.thickness * 1.1 : -18;
+      withClip(ctx, meta, () => {
+        ctx.translate(x, y);
+        ctx.fillStyle = '#f7c1d8';
+        ctx.beginPath();
+        ctx.ellipse(-6, -2, 6, 8, 0, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.beginPath();
+        ctx.ellipse(6, -2, 6, 8, 0, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = '#f38aad';
+        ctx.beginPath();
+        ctx.arc(0, -2, 3.4, 0, Math.PI * 2);
+        ctx.fill();
+      });
     }
   },
   'Bell Charm': {
     icon: '🔔',
     description: 'A gentle bell that jingles as the cow trots.',
-    svg: () => `
-          <g class="acc acc-bell" transform="translate(0,14)">
+    svg: (_cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.95 : 14;
+      return `
+          <g class="acc acc-bell" transform="translate(0,${fmt(y)})">
             <path d="M-6 0 Q0 -8 6 0 V4 H-6 Z" fill="#f4d38b" stroke="#d6a442" stroke-width="1" />
             <circle cx="0" cy="3" r="1.8" fill="#d6a442" />
-          </g>`,
-    draw: ctx => {
+          </g>`;
+    },
+    draw: (ctx, _cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.95 : 14;
       ctx.save();
-      ctx.translate(0, 14);
+      ctx.translate(0, y);
       ctx.beginPath();
       ctx.moveTo(-6, 0);
       ctx.quadraticCurveTo(0, -8, 6, 0);
@@ -66,90 +98,126 @@ export const AccessoryLibrary: Record<string, AccessoryEntry> = {
   'Sun Hat': {
     icon: '👒',
     description: 'A straw hat to keep the Highland sun at bay.',
-    svg: () => `
-          <g class="acc acc-hat" transform="translate(0,-34)">
+    svg: (_cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.horns.tipY + anatomy.horns.thickness * 0.6 : -34;
+      const scaleX = anatomy ? anatomy.head.width / 56 : 1;
+      const transform = `translate(0,${fmt(y)})${scaleX !== 1 ? ` scale(${fmt(scaleX)} 1)` : ''}`;
+      return `
+          <g class="acc acc-hat"${clipAttribute(meta)} transform="${transform}">
             <ellipse cx="0" cy="0" rx="28" ry="10" fill="#f3d9a4" stroke="#d6a067" stroke-width="1.4" />
             <ellipse cx="0" cy="-6" rx="18" ry="10" fill="#f8e7bf" stroke="#d6a067" stroke-width="1.2" />
             <path d="M-12 -4 Q0 -10 12 -4" stroke="#f2a9b7" stroke-width="3" fill="none" />
-          </g>`,
-    draw: ctx => {
-      ctx.save();
-      ctx.translate(0, -34);
-      ctx.fillStyle = '#f3d9a4';
-      ctx.strokeStyle = '#d6a067';
-      ctx.lineWidth = 1.4;
-      ctx.beginPath();
-      ctx.ellipse(0, 0, 28, 10, 0, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.stroke();
-      ctx.fillStyle = '#f8e7bf';
-      ctx.lineWidth = 1.2;
-      ctx.beginPath();
-      ctx.ellipse(0, -6, 18, 10, 0, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.strokeStyle = '#f2a9b7';
-      ctx.lineWidth = 3;
-      ctx.moveTo(-12, -4);
-      ctx.quadraticCurveTo(0, -10, 12, -4);
-      ctx.stroke();
-      ctx.restore();
+          </g>`;
+    },
+    draw: (ctx, _cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.horns.tipY + anatomy.horns.thickness * 0.6 : -34;
+      const scaleX = anatomy ? anatomy.head.width / 56 : 1;
+      withClip(ctx, meta, () => {
+        ctx.translate(0, y);
+        if (scaleX !== 1) {
+          ctx.scale(scaleX, 1);
+        }
+        ctx.fillStyle = '#f3d9a4';
+        ctx.strokeStyle = '#d6a067';
+        ctx.lineWidth = 1.4;
+        ctx.beginPath();
+        ctx.ellipse(0, 0, 28, 10, 0, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+        ctx.fillStyle = '#f8e7bf';
+        ctx.lineWidth = 1.2;
+        ctx.beginPath();
+        ctx.ellipse(0, -6, 18, 10, 0, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.strokeStyle = '#f2a9b7';
+        ctx.lineWidth = 3;
+        ctx.moveTo(-12, -4);
+        ctx.quadraticCurveTo(0, -10, 12, -4);
+        ctx.stroke();
+      });
     }
   },
   'Fern Garland': {
     icon: '🌿',
     description: 'Braided fern fronds draped across the horns.',
-    svg: () => `
-          <g class="acc acc-fern" transform="translate(0,-18)">
+    svg: (_cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.horns.baseY + anatomy.horns.thickness * 0.4 : -18;
+      const scaleX = anatomy ? anatomy.horns.outerSpread / 34 : 1;
+      const transform = `translate(0,${fmt(y)})${scaleX !== 1 ? ` scale(${fmt(scaleX)} 1)` : ''}`;
+      return `
+          <g class="acc acc-fern"${clipAttribute(meta)} transform="${transform}">
             <path d="M-34 -4 Q-12 -12 0 -6 T34 -4" fill="none" stroke="#7fb991" stroke-width="4" stroke-linecap="round" />
             <path d="M-24 -6 l-3 -6 l5 2 z" fill="#6aa67d" />
             <path d="M-12 -10 l-3 -6 l5 2 z" fill="#6aa67d" />
             <path d="M12 -10 l3 -6 l-5 2 z" fill="#6aa67d" />
             <path d="M24 -6 l3 -6 l-5 2 z" fill="#6aa67d" />
-          </g>`,
-    draw: ctx => {
-      ctx.save();
-      ctx.translate(0, -18);
-      ctx.strokeStyle = '#7fb991';
-      ctx.lineWidth = 4;
-      ctx.lineCap = 'round';
-      ctx.beginPath();
-      ctx.moveTo(-34, -4);
-      ctx.quadraticCurveTo(-12, -12, 0, -6);
-      ctx.quadraticCurveTo(12, -0, 34, -4);
-      ctx.stroke();
-      ctx.fillStyle = '#6aa67d';
-      const leaves = [
-        { x: -24, y: -6 },
-        { x: -12, y: -10 },
-        { x: 12, y: -10 },
-        { x: 24, y: -6 }
-      ];
-      leaves.forEach(({ x, y }) => {
+          </g>`;
+    },
+    draw: (ctx, _cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.horns.baseY + anatomy.horns.thickness * 0.4 : -18;
+      const scaleX = anatomy ? anatomy.horns.outerSpread / 34 : 1;
+      withClip(ctx, meta, () => {
+        ctx.translate(0, y);
+        if (scaleX !== 1) {
+          ctx.scale(scaleX, 1);
+        }
+        ctx.strokeStyle = '#7fb991';
+        ctx.lineWidth = 4;
+        ctx.lineCap = 'round';
         ctx.beginPath();
-        ctx.moveTo(x, y);
-        ctx.lineTo(x - 3, y - 6);
-        ctx.lineTo(x + 2, y - 4);
-        ctx.closePath();
-        ctx.fill();
+        ctx.moveTo(-34, -4);
+        ctx.quadraticCurveTo(-12, -12, 0, -6);
+        ctx.quadraticCurveTo(12, -0, 34, -4);
+        ctx.stroke();
+        ctx.fillStyle = '#6aa67d';
+        const leaves = [
+          { x: -24, y: -6 },
+          { x: -12, y: -10 },
+          { x: 12, y: -10 },
+          { x: 24, y: -6 }
+        ];
+        leaves.forEach(({ x, y }) => {
+          ctx.beginPath();
+          ctx.moveTo(x, y);
+          ctx.lineTo(x - 3, y - 6);
+          ctx.lineTo(x + 2, y - 4);
+          ctx.closePath();
+          ctx.fill();
+        });
       });
-      ctx.restore();
     }
   },
   'Starry Bandana': {
     icon: '🧣',
     description: 'A midnight blue bandana dotted with stars.',
-    svg: () => `
-          <g class="acc acc-bandana" transform="translate(0,12)">
+    svg: (_cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.55 : 12;
+      const scaleX = anatomy ? anatomy.head.width / 44 : 1;
+      const transform = `translate(0,${fmt(y)})${scaleX !== 1 ? ` scale(${fmt(scaleX)} 1)` : ''}`;
+      return `
+          <g class="acc acc-bandana" transform="${transform}">
             <path d="M-22 -2 L0 10 L22 -2 Z" fill="#3b3b7d" stroke="#272757" stroke-width="1.2" />
             <circle cx="-10" cy="2" r="1.5" fill="#f7e27d" />
             <circle cx="0" cy="4" r="1.2" fill="#f7e27d" />
             <circle cx="10" cy="2" r="1.5" fill="#f7e27d" />
-          </g>`,
-    draw: ctx => {
+          </g>`;
+    },
+    draw: (ctx, _cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.55 : 12;
+      const scaleX = anatomy ? anatomy.head.width / 44 : 1;
       ctx.save();
-      ctx.translate(0, 12);
+      ctx.translate(0, y);
+      if (scaleX !== 1) {
+        ctx.scale(scaleX, 1);
+      }
       ctx.beginPath();
       ctx.moveTo(-22, -2);
       ctx.lineTo(0, 10);
@@ -172,15 +240,27 @@ export const AccessoryLibrary: Record<string, AccessoryEntry> = {
   'Woolly Scarf': {
     icon: '🧶',
     description: 'A cosy knitted scarf for brisk mornings.',
-    svg: () => `
-          <g class="acc acc-scarf" transform="translate(0,18)">
+    svg: (_cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.82 : 18;
+      const scaleX = anatomy ? anatomy.head.width / 52 : 1;
+      const transform = `translate(0,${fmt(y)})${scaleX !== 1 ? ` scale(${fmt(scaleX)} 1)` : ''}`;
+      return `
+          <g class="acc acc-scarf" transform="${transform}">
             <path d="M-26 -6 Q0 6 26 -6 L22 6 Q0 16 -22 6 Z" fill="#f2a9b7" stroke="#c97a8a" stroke-width="1.2" />
             <path d="M-6 -4 V12" stroke="#c97a8a" stroke-width="3" stroke-linecap="round" />
             <path d="M6 -4 V12" stroke="#c97a8a" stroke-width="3" stroke-linecap="round" />
-          </g>`,
-    draw: ctx => {
+          </g>`;
+    },
+    draw: (ctx, _cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.82 : 18;
+      const scaleX = anatomy ? anatomy.head.width / 52 : 1;
       ctx.save();
-      ctx.translate(0, 18);
+      ctx.translate(0, y);
+      if (scaleX !== 1) {
+        ctx.scale(scaleX, 1);
+      }
       ctx.beginPath();
       ctx.moveTo(-26, -6);
       ctx.quadraticCurveTo(0, 6, 26, -6);
@@ -206,8 +286,13 @@ export const AccessoryLibrary: Record<string, AccessoryEntry> = {
   'Thistle Crown': {
     icon: '🌸',
     description: 'Highland thistles woven into a proud little crown.',
-    svg: () => `
-          <g class="acc acc-thistle" transform="translate(0,-26)">
+    svg: (_cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.horns.baseY - anatomy.horns.thickness * 0.2 : -26;
+      const scaleX = anatomy ? anatomy.horns.outerSpread / 26 : 1;
+      const transform = `translate(0,${fmt(y)})${scaleX !== 1 ? ` scale(${fmt(scaleX)} 1)` : ''}`;
+      return `
+          <g class="acc acc-thistle"${clipAttribute(meta)} transform="${transform}">
             <path d="M-26 -4 Q0 -10 26 -4" fill="none" stroke="#7fb991" stroke-width="3" stroke-linecap="round" />
             <circle cx="-16" cy="-8" r="4" fill="#c181d8" />
             <circle cx="0" cy="-12" r="4.5" fill="#b56ccc" />
@@ -215,35 +300,42 @@ export const AccessoryLibrary: Record<string, AccessoryEntry> = {
             <path d="M-16 -8 l-2 -6" stroke="#7fb991" stroke-width="2" />
             <path d="M0 -12 l-2 -6" stroke="#7fb991" stroke-width="2" />
             <path d="M16 -8 l2 -6" stroke="#7fb991" stroke-width="2" />
-          </g>`,
-    draw: ctx => {
-      ctx.save();
-      ctx.translate(0, -26);
-      ctx.strokeStyle = '#7fb991';
-      ctx.lineWidth = 3;
-      ctx.lineCap = 'round';
-      ctx.beginPath();
-      ctx.moveTo(-26, -4);
-      ctx.quadraticCurveTo(0, -10, 26, -4);
-      ctx.stroke();
-      const blooms = [
-        { x: -16, y: -8, r: 4, colour: '#c181d8' },
-        { x: 0, y: -12, r: 4.5, colour: '#b56ccc' },
-        { x: 16, y: -8, r: 4, colour: '#c181d8' }
-      ];
-      blooms.forEach(({ x, y, r, colour }) => {
-        ctx.beginPath();
-        ctx.fillStyle = colour;
-        ctx.arc(x, y, r, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.beginPath();
-        ctx.lineWidth = 2;
-        ctx.moveTo(x, y);
-        ctx.lineTo(x + (x === 0 ? -2 : Math.sign(x) * -2), y - 6);
+          </g>`;
+    },
+    draw: (ctx, _cow, meta) => {
+      const anatomy = meta?.anatomy;
+      const y = anatomy ? anatomy.horns.baseY - anatomy.horns.thickness * 0.2 : -26;
+      const scaleX = anatomy ? anatomy.horns.outerSpread / 26 : 1;
+      withClip(ctx, meta, () => {
+        ctx.translate(0, y);
+        if (scaleX !== 1) {
+          ctx.scale(scaleX, 1);
+        }
         ctx.strokeStyle = '#7fb991';
+        ctx.lineWidth = 3;
+        ctx.lineCap = 'round';
+        ctx.beginPath();
+        ctx.moveTo(-26, -4);
+        ctx.quadraticCurveTo(0, -10, 26, -4);
         ctx.stroke();
+        const blooms = [
+          { x: -16, y: -8, r: 4, colour: '#c181d8' },
+          { x: 0, y: -12, r: 4.5, colour: '#b56ccc' },
+          { x: 16, y: -8, r: 4, colour: '#c181d8' }
+        ];
+        blooms.forEach(({ x, y, r, colour }) => {
+          ctx.beginPath();
+          ctx.fillStyle = colour;
+          ctx.arc(x, y, r, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.beginPath();
+          ctx.lineWidth = 2;
+          ctx.moveTo(x, y);
+          ctx.lineTo(x + (x === 0 ? -2 : Math.sign(x) * -2), y - 6);
+          ctx.strokeStyle = '#7fb991';
+          ctx.stroke();
+        });
       });
-      ctx.restore();
     }
   }
 };

--- a/highland-cow-farm/src/game/cowVisuals.ts
+++ b/highland-cow-farm/src/game/cowVisuals.ts
@@ -10,6 +10,125 @@ export interface CowVisualOptions {
   rotation?: number;
   className?: string;
   viewBox?: string;
+  traits?: Partial<CowTraits>;
+  animations?: {
+    idleWobble?: boolean;
+  };
+}
+
+export interface CowTraits {
+  sleepyEyes: boolean;
+  rosyCheeks: boolean;
+  fancyLashes: boolean;
+  raisedBrow: boolean;
+}
+
+export interface CowAnatomy {
+  body: {
+    centerY: number;
+    rx: number;
+    ry: number;
+    highlightRx: number;
+    highlightRy: number;
+  };
+  head: {
+    width: number;
+    height: number;
+    centerY: number;
+  };
+  horns: {
+    baseY: number;
+    tipY: number;
+    innerSpread: number;
+    outerSpread: number;
+    thickness: number;
+  };
+  ears: {
+    baseY: number;
+    width: number;
+    height: number;
+    tilt: number;
+  };
+  muzzle: {
+    y: number;
+    width: number;
+    height: number;
+    nostrilOffset: number;
+  };
+  hooves: {
+    y: number;
+    width: number;
+    height: number;
+    spacing: number;
+  };
+  eyes: {
+    y: number;
+    spacing: number;
+    radius: number;
+  };
+  cheeks: {
+    y: number;
+    spacing: number;
+    radius: number;
+  };
+  fringe: {
+    layers: Array<{ width: number; height: number; offsetY: number }>;
+    swoopDepth: number;
+    bangDepth: number;
+  };
+}
+
+interface CowScaleMeta {
+  scale: number;
+  bellyOffset: number;
+  bellyStretch: number;
+  chonkBoost: number;
+  anatomy: CowAnatomy;
+}
+
+export interface AccessoryRenderMeta {
+  anatomy: CowAnatomy;
+  clipAboveHead: { y: number; height: number };
+  clipPathId?: string;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const normalized = hex.replace('#', '');
+  const bigint = parseInt(normalized, 16);
+  return {
+    r: (bigint >> 16) & 255,
+    g: (bigint >> 8) & 255,
+    b: bigint & 255
+  };
+}
+
+function mixColour(base: string, withColour: string, amount: number): string {
+  const a = hexToRgb(base);
+  const b = hexToRgb(withColour);
+  const r = Math.round(a.r + (b.r - a.r) * amount);
+  const g = Math.round(a.g + (b.g - a.g) * amount);
+  const bl = Math.round(a.b + (b.b - a.b) * amount);
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${bl.toString(16).padStart(2, '0')}`;
+}
+
+function lighten(colour: string, amount: number): string {
+  return mixColour(colour, '#ffffff', clamp(amount, 0, 1));
+}
+
+function darken(colour: string, amount: number): string {
+  return mixColour(colour, '#000000', clamp(amount, 0, 1));
+}
+
+function toKebabCase(value: string): string {
+  return value.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+function fmt(value: number): string {
+  return Number.isFinite(value) ? Number(value.toFixed(3)).toString() : '0';
 }
 
 const colourMap: Record<string, string> = {
@@ -24,23 +143,28 @@ export function colourHex(colour: string): string {
   return colourMap[colour] || colourMap.brown;
 }
 
-function accessoriesSVG(cow: Cow): string {
+function accessoriesSVG(cow: Cow, meta: AccessoryRenderMeta): string {
   return (cow.accessories || [])
     .map(name => {
       const entry = AccessoryLibrary[name];
-      return entry && typeof entry.svg === 'function' ? entry.svg(cow) : '';
+      return entry && typeof entry.svg === 'function' ? entry.svg(cow, meta) : '';
     })
     .join('');
 }
 
-function drawAccessories(ctx: CanvasRenderingContext2D, cow: Cow, meta: CowVisualOptions): void {
+function drawAccessories(
+  ctx: CanvasRenderingContext2D,
+  cow: Cow,
+  meta: CowVisualOptions & AccessoryRenderMeta,
+): void {
   (cow.accessories || []).forEach(name => {
     const entry = AccessoryLibrary[name];
     if (entry && typeof entry.draw === 'function') {
       entry.draw(ctx, cow, meta);
     } else if (entry && entry.icon) {
       ctx.save();
-      ctx.translate(0, -26);
+      const fallbackY = meta.anatomy.head.centerY - meta.anatomy.head.height * 0.4;
+      ctx.translate(0, fallbackY);
       ctx.font = '18px sans-serif';
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
@@ -50,13 +174,217 @@ function drawAccessories(ctx: CanvasRenderingContext2D, cow: Cow, meta: CowVisua
   });
 }
 
-function computeScale(cow: Cow, options: CowVisualOptions = {}) {
+function computeScale(cow: Cow, options: CowVisualOptions = {}): CowScaleMeta {
   const chonkBoost = Math.max(0, (cow.chonk || 0) - 60);
   const baseScale = options.scale || 1;
   const scale = baseScale * (1 + Math.min(0.22, chonkBoost / 160));
   const bellyOffset = Math.min(10, chonkBoost * 0.2);
   const bellyStretch = Math.min(9, chonkBoost * 0.18);
-  return { scale, bellyOffset, bellyStretch, chonkBoost };
+
+  const bodyCenterY = 28 + bellyOffset;
+  const bodyRx = 40 + bellyStretch;
+  const bodyRy = 28 + bellyStretch * 0.9;
+  const bodyHighlightRx = 24 + bellyStretch * 0.5;
+  const bodyHighlightRy = 12 + bellyStretch * 0.4;
+
+  const headWidth = 58 + Math.min(6, chonkBoost * 0.08);
+  const headHeight = 44 + Math.min(5, chonkBoost * 0.05);
+  const headCenterY = -4 + Math.min(2.4, chonkBoost * 0.04);
+  const headTop = headCenterY - headHeight / 2;
+
+  const hornsThickness = 8 + Math.min(2.5, chonkBoost * 0.04);
+  const hornsBaseY = headTop - 4;
+  const hornsTipY = hornsBaseY - (16 + Math.min(5, chonkBoost * 0.05));
+  const hornsInnerSpread = headWidth * 0.34;
+  const hornsOuterSpread = headWidth * 0.74;
+
+  const earsHeight = headHeight * 0.58;
+
+  const anatomy: CowAnatomy = {
+    body: {
+      centerY: bodyCenterY,
+      rx: bodyRx,
+      ry: bodyRy,
+      highlightRx: bodyHighlightRx,
+      highlightRy: bodyHighlightRy,
+    },
+    head: {
+      width: headWidth,
+      height: headHeight,
+      centerY: headCenterY,
+    },
+    horns: {
+      baseY: hornsBaseY,
+      tipY: hornsTipY,
+      innerSpread: hornsInnerSpread,
+      outerSpread: hornsOuterSpread,
+      thickness: hornsThickness,
+    },
+    ears: {
+      baseY: headCenterY - headHeight * 0.08,
+      width: headWidth * 0.32,
+      height: earsHeight,
+      tilt: 0.28 + Math.min(0.12, chonkBoost / 520),
+    },
+    muzzle: {
+      y: headCenterY + headHeight * 0.42,
+      width: headWidth * 0.52,
+      height: headHeight * 0.42 + Math.min(2.4, chonkBoost * 0.03),
+      nostrilOffset: headWidth * 0.18,
+    },
+    hooves: {
+      y: bodyCenterY + bodyRy - 4,
+      width: 12 + Math.min(3, chonkBoost * 0.04),
+      height: 8 + Math.min(3, chonkBoost * 0.03),
+      spacing: 26 + Math.min(6, chonkBoost * 0.07),
+    },
+    eyes: {
+      y: headCenterY + headHeight * 0.04,
+      spacing: headWidth * 0.32,
+      radius: 4.4 + Math.min(0.8, chonkBoost * 0.01),
+    },
+    cheeks: {
+      y: headCenterY + headHeight * 0.32,
+      spacing: headWidth * 0.36,
+      radius: headHeight * 0.22,
+    },
+    fringe: {
+      layers: [
+        { width: headWidth * 0.98, height: headHeight * 0.7, offsetY: -headHeight * 0.1 },
+        { width: headWidth * 0.86, height: headHeight * 0.54, offsetY: headHeight * 0.02 },
+        { width: headWidth * 0.7, height: headHeight * 0.36, offsetY: headHeight * 0.18 },
+      ],
+      swoopDepth: headHeight * 0.62,
+      bangDepth: headHeight * 0.32,
+    },
+  };
+
+  return { scale, bellyOffset, bellyStretch, chonkBoost, anatomy };
+}
+
+function baseTraits(cow: Cow): CowTraits {
+  return {
+    sleepyEyes: cow.personality === 'Sleepy',
+    rosyCheeks: cow.personality === 'Social' || cow.personality === 'Vain',
+    fancyLashes: cow.personality === 'Vain',
+    raisedBrow: cow.personality === 'Greedy',
+  };
+}
+
+function resolveTraits(cow: Cow, options: CowVisualOptions): CowTraits {
+  const traits = baseTraits(cow);
+  if (options.traits) {
+    (Object.entries(options.traits) as Array<[keyof CowTraits, boolean | undefined]>).forEach(([key, value]) => {
+      if (typeof value === 'boolean') {
+        traits[key] = value;
+      }
+    });
+  }
+  return traits;
+}
+
+function hornPath(anatomy: CowAnatomy, side: 'left' | 'right'): string {
+  const { horns } = anatomy;
+  const dir = side === 'left' ? -1 : 1;
+  const baseX = dir * horns.innerSpread;
+  const baseY = horns.baseY;
+  const tipX = dir * horns.outerSpread;
+  const tipY = horns.tipY;
+  const thickness = horns.thickness;
+  const upperCtrlX = dir * (horns.innerSpread + 6);
+  const upperCtrlY = baseY - thickness * 1.1;
+  const upperCtrl2X = dir * (horns.outerSpread - 8);
+  const upperCtrl2Y = tipY - thickness * 0.6;
+  const lowerCtrl1X = dir * (horns.outerSpread + 6);
+  const lowerCtrl1Y = tipY + thickness * 1.2;
+  const lowerCtrl2X = dir * (horns.innerSpread + 10);
+  const lowerCtrl2Y = baseY + thickness * 0.8;
+  const bottomY = baseY + thickness + 2;
+  return `M${fmt(baseX)},${fmt(baseY)} C${fmt(upperCtrlX)},${fmt(upperCtrlY)} ${fmt(upperCtrl2X)},${fmt(upperCtrl2Y)} ${fmt(tipX)},${fmt(tipY)} C${fmt(lowerCtrl1X)},${fmt(lowerCtrl1Y)} ${fmt(lowerCtrl2X)},${fmt(lowerCtrl2Y)} ${fmt(baseX)},${fmt(bottomY)} Z`;
+}
+
+function hornHighlightPath(anatomy: CowAnatomy, side: 'left' | 'right'): string {
+  const { horns } = anatomy;
+  const dir = side === 'left' ? -1 : 1;
+  const startX = dir * (horns.innerSpread + 3);
+  const startY = horns.baseY + horns.thickness * 0.2;
+  const controlX = dir * (horns.innerSpread + horns.outerSpread) * 0.5;
+  const controlY = horns.tipY + horns.thickness * 0.3;
+  const endX = dir * (horns.outerSpread - 2);
+  const endY = horns.tipY + horns.thickness * 0.6;
+  return `M${fmt(startX)},${fmt(startY)} Q${fmt(controlX)},${fmt(controlY)} ${fmt(endX)},${fmt(endY)}`;
+}
+
+function earPath(anatomy: CowAnatomy, side: 'left' | 'right'): string {
+  const { ears, head } = anatomy;
+  const dir = side === 'left' ? -1 : 1;
+  const baseX = dir * (head.width * 0.46);
+  const baseY = ears.baseY;
+  const tipX = dir * (head.width * (0.76 + ears.tilt * 0.2));
+  const tipY = baseY - ears.height;
+  const frontCtrlX = dir * (head.width * (0.64 + ears.tilt * 0.4));
+  const frontCtrlY = baseY - ears.height * 0.6;
+  const rearCtrlX = dir * (head.width * 0.68);
+  const rearCtrlY = baseY + ears.height * 0.18;
+  const lowerX = dir * (head.width * 0.44);
+  const lowerY = baseY + ears.height * 0.52;
+  const innerX = dir * (head.width * 0.38);
+  const innerY = baseY + ears.height * 0.22;
+  return `M${fmt(baseX)},${fmt(baseY)} Q${fmt(frontCtrlX)},${fmt(frontCtrlY)} ${fmt(tipX)},${fmt(tipY)} Q${fmt(rearCtrlX)},${fmt(rearCtrlY)} ${fmt(lowerX)},${fmt(lowerY)} Q${fmt(innerX)},${fmt(innerY)} ${fmt(baseX)},${fmt(baseY)} Z`;
+}
+
+function earInnerPath(anatomy: CowAnatomy, side: 'left' | 'right'): string {
+  const { ears, head } = anatomy;
+  const dir = side === 'left' ? -1 : 1;
+  const baseX = dir * (head.width * 0.44);
+  const baseY = ears.baseY + ears.height * 0.12;
+  const tipX = dir * (head.width * (0.64 + ears.tilt * 0.12));
+  const tipY = baseY - ears.height * 0.72;
+  const innerCtrlX = dir * (head.width * 0.52);
+  const innerCtrlY = baseY + ears.height * 0.24;
+  return `M${fmt(baseX)},${fmt(baseY)} Q${fmt(innerCtrlX)},${fmt(innerCtrlY)} ${fmt(tipX)},${fmt(tipY)} Q${fmt(dir * (head.width * 0.54))},${fmt(baseY + ears.height * 0.18)} ${fmt(baseX)},${fmt(baseY)} Z`;
+}
+
+function fringeLayerPath(anatomy: CowAnatomy, index: number): string {
+  const layer = anatomy.fringe.layers[index];
+  const centerY = anatomy.head.centerY + layer.offsetY;
+  const width = layer.width;
+  const height = layer.height;
+  const left = -width / 2;
+  const right = width / 2;
+  const bottomY = centerY + height / 2;
+  const topY = centerY - anatomy.fringe.swoopDepth * (0.58 - index * 0.08);
+  return `M${fmt(left)},${fmt(bottomY)} C${fmt(left + width * 0.18)},${fmt(topY)} ${fmt(right - width * 0.18)},${fmt(topY)} ${fmt(right)},${fmt(bottomY)} Q0,${fmt(bottomY + height * 0.22)} ${fmt(left)},${fmt(bottomY)} Z`;
+}
+
+function fringeBangPath(anatomy: CowAnatomy): string {
+  const width = anatomy.head.width * 0.94;
+  const left = -width / 2;
+  const right = width / 2;
+  const bottomY = anatomy.head.centerY + anatomy.head.height * 0.18;
+  const topY = anatomy.head.centerY - anatomy.fringe.bangDepth;
+  return `M${fmt(left)},${fmt(bottomY)} Q${fmt(left * 0.4)},${fmt(topY)} 0,${fmt(topY + 6)} Q${fmt(right * 0.4)},${fmt(topY)} ${fmt(right)},${fmt(bottomY)} Z`;
+}
+
+function mouthPath(anatomy: CowAnatomy): string {
+  const width = anatomy.muzzle.width * 0.5;
+  const left = -width / 2;
+  const right = width / 2;
+  const mouthY = anatomy.muzzle.y + anatomy.muzzle.height * 0.18;
+  return `M${fmt(left)},${fmt(mouthY)} Q0,${fmt(mouthY + anatomy.muzzle.height * 0.16)} ${fmt(right)},${fmt(mouthY)}`;
+}
+
+function browPath(anatomy: CowAnatomy, side: 'left' | 'right'): string {
+  const dir = side === 'left' ? -1 : 1;
+  const outerX = dir * (anatomy.eyes.spacing * 0.7);
+  const innerX = dir * (anatomy.eyes.spacing * 0.24);
+  const browY = anatomy.eyes.y - anatomy.eyes.radius * 1.8;
+  return `M${fmt(outerX)},${fmt(browY)} Q${fmt(dir * (anatomy.eyes.spacing * 0.35))},${fmt(browY - 2)} ${fmt(innerX)},${fmt(browY - 0.4)}`;
+}
+
+function eyePositions(anatomy: CowAnatomy): { left: number; right: number } {
+  const half = anatomy.eyes.spacing / 2;
+  return { left: -half, right: half };
 }
 
 export function drawCanvas(
@@ -64,10 +392,25 @@ export function drawCanvas(
   cow: Cow,
   options: CowVisualOptions = {}
 ): void {
-  const { scale, bellyOffset, bellyStretch } = computeScale(cow, options);
+  const { scale, anatomy } = computeScale(cow, options);
   const body = colourHex(cow.colour);
   const fringeColour = colourHex(cow.colour === 'white' ? 'cream' : cow.colour);
-  const wobble = options.wobble || 0;
+  const muzzleColour = lighten(body, 0.28);
+  const hornColour = lighten(body, 0.4);
+  const hoofColour = darken(body, 0.35);
+  const earOuter = darken(fringeColour, 0.08);
+  const earInner = lighten(fringeColour, 0.2);
+  const fringeShadow = darken(fringeColour, 0.18);
+  const fringeHighlight = lighten(fringeColour, 0.16);
+  const outlineColour = darken(body, 0.2);
+  const cheekColour = mixColour(fringeColour, '#f597b3', 0.55);
+  const traits = resolveTraits(cow, options);
+  const idleWobble = options.animations?.idleWobble !== false;
+  const wobble = idleWobble ? options.wobble || 0 : 0;
+  const bodyRy = anatomy.body.ry + wobble * 0.15;
+  const clipTop = Math.min(anatomy.horns.tipY - 12, anatomy.head.centerY - anatomy.head.height * 0.5);
+  const clipBottom = anatomy.head.centerY - anatomy.head.height * 0.05;
+  const clipHeight = Math.max(0, clipBottom - clipTop);
   ctx.save();
   if (options.x || options.y) {
     ctx.translate(options.x || 0, options.y || 0);
@@ -77,66 +420,377 @@ export function drawCanvas(
   }
   ctx.scale(scale, scale);
   ctx.translate(0, options.offsetY || 0);
+  // Body
   ctx.fillStyle = body;
   ctx.beginPath();
-  ctx.ellipse(0, 28 + bellyOffset, 40 + bellyStretch, 28 + bellyStretch * 0.9 + wobble * 0.15, 0, 0, Math.PI * 2);
+  ctx.ellipse(0, anatomy.body.centerY, anatomy.body.rx, bodyRy, 0, 0, Math.PI * 2);
   ctx.fill();
+
+  ctx.fillStyle = 'rgba(0,0,0,0.08)';
+  ctx.beginPath();
+  ctx.ellipse(
+    0,
+    anatomy.body.centerY + anatomy.body.ry * 0.4,
+    anatomy.body.rx * 0.7,
+    bodyRy * 0.5,
+    0,
+    0,
+    Math.PI * 2,
+  );
+  ctx.fill();
+
   ctx.fillStyle = 'rgba(255,255,255,0.16)';
   ctx.beginPath();
-  ctx.ellipse(0, 28 + bellyOffset, 24 + bellyStretch * 0.5, 12 + bellyStretch * 0.4, 0, 0, Math.PI * 2);
+  ctx.ellipse(
+    0,
+    anatomy.body.centerY - anatomy.body.ry * 0.2,
+    anatomy.body.highlightRx,
+    anatomy.body.highlightRy,
+    0,
+    0,
+    Math.PI * 2,
+  );
   ctx.fill();
-  ctx.strokeStyle = body;
-  ctx.lineWidth = 8;
-  ctx.lineCap = 'round';
-  ctx.beginPath();
-  ctx.moveTo(-28, -6);
-  ctx.quadraticCurveTo(-58, -26, -34, -38);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.moveTo(28, -6);
-  ctx.quadraticCurveTo(58, -26, 34, -38);
-  ctx.stroke();
+
+  // Hooves
+  ctx.fillStyle = hoofColour;
+  [-1, 1].forEach(direction => {
+    const x = direction * anatomy.hooves.spacing * 0.5;
+    ctx.beginPath();
+    ctx.ellipse(x, anatomy.hooves.y, anatomy.hooves.width, anatomy.hooves.height, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(255,255,255,0.25)';
+    ctx.lineWidth = 1.1;
+    ctx.beginPath();
+    ctx.ellipse(
+      x,
+      anatomy.hooves.y - anatomy.hooves.height * 0.25,
+      anatomy.hooves.width * 0.7,
+      anatomy.hooves.height * 0.45,
+      0,
+      0,
+      Math.PI * 2,
+    );
+    ctx.stroke();
+  });
+
+  // Horns
+  ['left', 'right'].forEach(side => {
+    const path = new Path2D(hornPath(anatomy, side as 'left' | 'right'));
+    ctx.fillStyle = hornColour;
+    ctx.fill(path);
+    ctx.strokeStyle = darken(hornColour, 0.2);
+    ctx.lineWidth = 1.6;
+    ctx.stroke(path);
+    ctx.strokeStyle = 'rgba(255,255,255,0.45)';
+    ctx.lineWidth = 1.4;
+    ctx.lineCap = 'round';
+    ctx.stroke(new Path2D(hornHighlightPath(anatomy, side as 'left' | 'right')));
+  });
+
+  // Ears
+  ['left', 'right'].forEach(side => {
+    const outer = new Path2D(earPath(anatomy, side as 'left' | 'right'));
+    ctx.fillStyle = earOuter;
+    ctx.fill(outer);
+    ctx.strokeStyle = darken(earOuter, 0.12);
+    ctx.lineWidth = 1.2;
+    ctx.stroke(outer);
+    const inner = new Path2D(earInnerPath(anatomy, side as 'left' | 'right'));
+    ctx.fillStyle = earInner;
+    ctx.fill(inner);
+  });
+
+  // Head base
   ctx.fillStyle = fringeColour;
   ctx.beginPath();
-  ctx.ellipse(0, 0, 30, 26, 0, 0, Math.PI * 2);
+  ctx.ellipse(0, anatomy.head.centerY, anatomy.head.width / 2, anatomy.head.height / 2, 0, 0, Math.PI * 2);
   ctx.fill();
+  ctx.strokeStyle = fringeShadow;
+  ctx.lineWidth = 1.4;
+  ctx.stroke();
+
+  // Fringe layers
+  anatomy.fringe.layers.forEach((_, index) => {
+    const layerPath = new Path2D(fringeLayerPath(anatomy, index));
+    const fill = index === 0 ? fringeColour : index === 1 ? fringeHighlight : lighten(fringeColour, 0.28);
+    ctx.fillStyle = fill;
+    ctx.fill(layerPath);
+    ctx.strokeStyle = index === 0 ? darken(fringeShadow, 0.1) : 'rgba(53,38,77,0.08)';
+    ctx.lineWidth = 1.2;
+    ctx.stroke(layerPath);
+  });
+
+  const bang = new Path2D(fringeBangPath(anatomy));
+  ctx.fillStyle = fringeShadow;
+  ctx.fill(bang);
+  ctx.fillStyle = 'rgba(255,255,255,0.12)';
+  ctx.fill(new Path2D(fringeLayerPath(anatomy, Math.min(1, anatomy.fringe.layers.length - 1))));
+
+  // Muzzle
+  ctx.fillStyle = muzzleColour;
   ctx.beginPath();
-  ctx.moveTo(-20, -10);
-  ctx.quadraticCurveTo(0, -26, 20, -10);
-  ctx.closePath();
+  ctx.ellipse(0, anatomy.muzzle.y, anatomy.muzzle.width / 2, anatomy.muzzle.height / 2, 0, 0, Math.PI * 2);
   ctx.fill();
-  ctx.fillStyle = '#35264d';
+  ctx.strokeStyle = darken(muzzleColour, 0.28);
+  ctx.lineWidth = 1.2;
+  ctx.stroke();
+
+  ctx.fillStyle = 'rgba(255,255,255,0.22)';
   ctx.beginPath();
-  ctx.arc(-12, -2, 4, 0, Math.PI * 2);
-  ctx.arc(12, -2, 4, 0, Math.PI * 2);
+  ctx.ellipse(
+    0,
+    anatomy.muzzle.y - anatomy.muzzle.height * 0.2,
+    anatomy.muzzle.width * 0.32,
+    anatomy.muzzle.height * 0.26,
+    0,
+    0,
+    Math.PI * 2,
+  );
   ctx.fill();
+
+  const nostrilColour = darken(muzzleColour, 0.4);
+  [-1, 1].forEach(direction => {
+    const x = direction * anatomy.muzzle.nostrilOffset;
+    ctx.beginPath();
+    ctx.ellipse(x, anatomy.muzzle.y + anatomy.muzzle.height * 0.04, 3.2, 4.6, 0, 0, Math.PI * 2);
+    ctx.fillStyle = nostrilColour;
+    ctx.fill();
+  });
+
+  ctx.strokeStyle = darken(nostrilColour, 0.1);
+  ctx.lineWidth = 1.6;
+  ctx.lineCap = 'round';
+  ctx.stroke(new Path2D(mouthPath(anatomy)));
+
+  // Eyes
+  const eyes = eyePositions(anatomy);
+  const eyeColour = '#35264d';
+  Object.values(eyes).forEach(x => {
+    ctx.fillStyle = eyeColour;
+    ctx.beginPath();
+    ctx.arc(x, anatomy.eyes.y, anatomy.eyes.radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = 'rgba(255,255,255,0.4)';
+    ctx.beginPath();
+    ctx.arc(x - 1.2, anatomy.eyes.y - 1.4, anatomy.eyes.radius * 0.35, 0, Math.PI * 2);
+    ctx.fill();
+  });
+
+  if (traits.sleepyEyes) {
+    ctx.strokeStyle = lighten(fringeColour, 0.25);
+    ctx.lineWidth = 2.3;
+    Object.values(eyes).forEach(x => {
+      ctx.beginPath();
+      ctx.arc(x, anatomy.eyes.y - anatomy.eyes.radius * 0.1, anatomy.eyes.radius, Math.PI * 0.1, Math.PI - Math.PI * 0.1);
+      ctx.stroke();
+    });
+  }
+
+  if (traits.fancyLashes) {
+    ctx.strokeStyle = eyeColour;
+    ctx.lineWidth = 1.3;
+    Object.values(eyes).forEach(x => {
+      const top = anatomy.eyes.y - anatomy.eyes.radius - 0.6;
+      [[-2.2, -5], [0, -5.6], [2.2, -5]].forEach(([dx, dy]) => {
+        ctx.beginPath();
+        ctx.moveTo(x + dx, top);
+        ctx.lineTo(x + dx * 0.7, top + dy);
+        ctx.stroke();
+      });
+    });
+  }
+
+  if (traits.raisedBrow) {
+    ctx.strokeStyle = fringeShadow;
+    ctx.lineWidth = 1.6;
+    ctx.lineCap = 'round';
+    ['left', 'right'].forEach(side => {
+      ctx.stroke(new Path2D(browPath(anatomy, side as 'left' | 'right')));
+    });
+  }
+
+  if (traits.rosyCheeks) {
+    ctx.save();
+    ctx.globalAlpha = 0.55;
+    ctx.fillStyle = cheekColour;
+    [-1, 1].forEach(direction => {
+      const x = direction * anatomy.cheeks.spacing * 0.5;
+      ctx.beginPath();
+      ctx.arc(x, anatomy.cheeks.y, anatomy.cheeks.radius, 0, Math.PI * 2);
+      ctx.fill();
+    });
+    ctx.restore();
+  }
+
+  // Outline
+  ctx.strokeStyle = outlineColour;
+  ctx.lineWidth = 2.2;
   ctx.beginPath();
-  ctx.ellipse(0, 12, 8, 10, 0, 0, Math.PI * 2);
-  ctx.fill();
-  drawAccessories(ctx, cow, options);
+  ctx.ellipse(0, anatomy.body.centerY, anatomy.body.rx, bodyRy, 0, 0, Math.PI * 2);
+  ctx.stroke();
+
+  const accessoryMeta = {
+    ...options,
+    anatomy,
+    clipAboveHead: { y: clipTop, height: clipHeight },
+  } as CowVisualOptions & AccessoryRenderMeta;
+  drawAccessories(ctx, cow, accessoryMeta);
   ctx.restore();
 }
 
 export function svg(cow: Cow, options: CowVisualOptions = {}): string {
-  const { scale, bellyOffset, bellyStretch } = computeScale(cow, options);
+  const { scale, anatomy } = computeScale(cow, options);
   const viewBox = options.viewBox || '0 0 140 120';
   const className = options.className ? ` ${options.className}` : '';
   const offsetY = options.offsetY || 0;
   const body = colourHex(cow.colour);
   const fringeColour = colourHex(cow.colour === 'white' ? 'cream' : cow.colour);
+  const muzzleColour = lighten(body, 0.28);
+  const hornColour = lighten(body, 0.4);
+  const hoofColour = darken(body, 0.35);
+  const earOuter = darken(fringeColour, 0.08);
+  const earInner = lighten(fringeColour, 0.2);
+  const fringeShadow = darken(fringeColour, 0.18);
+  const fringeHighlight = lighten(fringeColour, 0.16);
+  const outlineColour = darken(body, 0.2);
+  const cheekColour = mixColour(fringeColour, '#f597b3', 0.55);
+  const nostrilColour = darken(muzzleColour, 0.4);
+  const traits = resolveTraits(cow, options);
+  const traitClasses = Object.entries(traits)
+    .filter(([, enabled]) => enabled)
+    .map(([key]) => ` cow-trait-${toKebabCase(key)}`)
+    .join('');
+  const personalityClass = ` cow-personality-${cow.personality.toLowerCase()}`;
+  const idleEnabled = options.animations?.idleWobble !== false;
+  const wobble = idleEnabled ? options.wobble || 0 : 0;
+  const bodyRy = anatomy.body.ry + wobble * 0.15;
+  const rootGroupClass = idleEnabled ? 'cow-root-group is-idle-wobble' : 'cow-root-group';
+  const idleClass = idleEnabled ? ' cow-art--idle-wobble' : '';
+  const hornsLeft = hornPath(anatomy, 'left');
+  const hornsRight = hornPath(anatomy, 'right');
+  const hornHighlightLeft = hornHighlightPath(anatomy, 'left');
+  const hornHighlightRight = hornHighlightPath(anatomy, 'right');
+  const earLeft = earPath(anatomy, 'left');
+  const earRight = earPath(anatomy, 'right');
+  const earInnerLeft = earInnerPath(anatomy, 'left');
+  const earInnerRight = earInnerPath(anatomy, 'right');
+  const fringeLayers = anatomy.fringe.layers.map((_, index) => fringeLayerPath(anatomy, index));
+  const fringeBang = fringeBangPath(anatomy);
+  const mouth = mouthPath(anatomy);
+  const eyes = eyePositions(anatomy);
+  const lidBase = anatomy.eyes.y - anatomy.eyes.radius * 0.1;
+  const lidPeak = lidBase - anatomy.eyes.radius * 0.8;
+  const sleepyLids = traits.sleepyEyes
+    ? `<path class="cow-eye-lid" d="M${fmt(eyes.left - anatomy.eyes.radius)} ${fmt(lidBase)} Q${fmt(eyes.left)} ${fmt(lidPeak)} ${fmt(eyes.left + anatomy.eyes.radius)} ${fmt(lidBase)}" stroke="${lighten(fringeColour, 0.25)}" stroke-width="2.3" fill="none" />
+       <path class="cow-eye-lid" d="M${fmt(eyes.right - anatomy.eyes.radius)} ${fmt(lidBase)} Q${fmt(eyes.right)} ${fmt(lidPeak)} ${fmt(eyes.right + anatomy.eyes.radius)} ${fmt(lidBase)}" stroke="${lighten(fringeColour, 0.25)}" stroke-width="2.3" fill="none" />`
+    : '';
+  const lashPaths = traits.fancyLashes
+    ? [-1, 1]
+        .map(direction => {
+          const cx = direction === -1 ? eyes.left : eyes.right;
+          const base = anatomy.eyes.y - anatomy.eyes.radius - 0.6;
+          return [
+            `<path d="M${fmt(cx - 2.2)},${fmt(base)} L${fmt(cx - 1.54)},${fmt(base - 5)}" stroke="#35264d" stroke-width="1.3" stroke-linecap="round" fill="none" />`,
+            `<path d="M${fmt(cx)},${fmt(base)} L${fmt(cx)},${fmt(base - 5.6)}" stroke="#35264d" stroke-width="1.3" stroke-linecap="round" fill="none" />`,
+            `<path d="M${fmt(cx + 2.2)},${fmt(base)} L${fmt(cx + 1.54)},${fmt(base - 5)}" stroke="#35264d" stroke-width="1.3" stroke-linecap="round" fill="none" />`,
+          ].join('');
+        })
+        .join('')
+    : '';
+  const browGroup = traits.raisedBrow
+    ? `<g class="cow-brows" stroke="${fringeShadow}" stroke-width="1.6" stroke-linecap="round" fill="none">
+         <path d="${browPath(anatomy, 'left')}" />
+         <path d="${browPath(anatomy, 'right')}" />
+       </g>`
+    : '';
+  const cheeksGroup = traits.rosyCheeks
+    ? `<g class="cow-cheeks" fill="${cheekColour}" opacity="0.55">
+         <circle cx="${fmt(-anatomy.cheeks.spacing * 0.5)}" cy="${fmt(anatomy.cheeks.y)}" r="${fmt(anatomy.cheeks.radius)}" />
+         <circle cx="${fmt(anatomy.cheeks.spacing * 0.5)}" cy="${fmt(anatomy.cheeks.y)}" r="${fmt(anatomy.cheeks.radius)}" />
+       </g>`
+    : '';
+  const hooves = [-1, 1]
+    .map(direction => {
+      const cx = fmt(direction * anatomy.hooves.spacing * 0.5);
+      return `
+        <g class="cow-hoof">
+          <ellipse cx="${cx}" cy="${fmt(anatomy.hooves.y)}" rx="${fmt(anatomy.hooves.width)}" ry="${fmt(anatomy.hooves.height)}" fill="${hoofColour}" />
+          <ellipse cx="${cx}" cy="${fmt(anatomy.hooves.y - anatomy.hooves.height * 0.25)}" rx="${fmt(anatomy.hooves.width * 0.7)}" ry="${fmt(anatomy.hooves.height * 0.45)}" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="1.1" />
+        </g>`;
+    })
+    .join('');
+  const sanitizedId = (cow.id || 'cow')
+    .toString()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '-');
+  const clipId = `cow-accessory-clip-${sanitizedId}`;
+  const clipTop = Math.min(anatomy.horns.tipY - 12, anatomy.head.centerY - anatomy.head.height * 0.5);
+  const clipBottom = anatomy.head.centerY - anatomy.head.height * 0.05;
+  const clipHeight = Math.max(0.1, clipBottom - clipTop);
+  const accessoryMeta = {
+    anatomy,
+    clipAboveHead: { y: clipTop, height: clipHeight },
+    clipPathId: clipId,
+  } as AccessoryRenderMeta;
+  const accessories = accessoriesSVG(cow, accessoryMeta);
+
   return `
-          <svg class="cow-art${className}" viewBox="${viewBox}" role="img" aria-label="${cow.name} the cow">
+          <svg class="cow-art${className}${personalityClass}${traitClasses}${idleClass}" viewBox="${viewBox}" role="img" aria-label="${cow.name} the cow">
+            <defs>
+              <clipPath id="${clipId}">
+                <rect x="-160" y="${fmt(clipTop)}" width="320" height="${fmt(clipHeight)}" />
+              </clipPath>
+            </defs>
             <g transform="translate(70 ${60 + offsetY}) scale(${scale.toFixed(3)})">
-              <ellipse cx="0" cy="${28 + bellyOffset}" rx="${40 + bellyStretch}" ry="${28 + bellyStretch * 0.9}" fill="${body}" />
-              <ellipse cx="0" cy="${28 + bellyOffset}" rx="${24 + bellyStretch * 0.5}" ry="${12 + bellyStretch * 0.4}" fill="rgba(255,255,255,0.16)" />
-              <path d="M-28,-6 Q-58,-26 -34,-38" stroke="${body}" stroke-width="8" stroke-linecap="round" fill="none" />
-              <path d="M28,-6 Q58,-26 34,-38" stroke="${body}" stroke-width="8" stroke-linecap="round" fill="none" />
-              <ellipse cx="0" cy="0" rx="30" ry="26" fill="${fringeColour}" />
-              <path d="M-20,-10 Q0,-26 20,-10" fill="${fringeColour}" />
-              <circle cx="-12" cy="-2" r="4" fill="#35264d" />
-              <circle cx="12" cy="-2" r="4" fill="#35264d" />
-              <ellipse cx="0" cy="12" rx="8" ry="10" fill="#35264d" />
-              ${accessoriesSVG(cow)}
+              <g class="${rootGroupClass}">
+                <g class="cow-body">
+                  <ellipse class="cow-body-fill" cx="0" cy="${fmt(anatomy.body.centerY)}" rx="${fmt(anatomy.body.rx)}" ry="${fmt(bodyRy)}" fill="${body}" />
+                  <ellipse class="cow-body-highlight" cx="0" cy="${fmt(anatomy.body.centerY - anatomy.body.ry * 0.2)}" rx="${fmt(anatomy.body.highlightRx)}" ry="${fmt(anatomy.body.highlightRy)}" fill="rgba(255,255,255,0.16)" />
+                  <ellipse class="cow-body-shade" cx="0" cy="${fmt(anatomy.body.centerY + anatomy.body.ry * 0.4)}" rx="${fmt(anatomy.body.rx * 0.7)}" ry="${fmt(bodyRy * 0.5)}" fill="rgba(0,0,0,0.08)" />
+                  <ellipse class="cow-body-outline" cx="0" cy="${fmt(anatomy.body.centerY)}" rx="${fmt(anatomy.body.rx)}" ry="${fmt(bodyRy)}" fill="none" stroke="${outlineColour}" stroke-width="2.2" />
+                </g>
+                <g class="cow-hooves">
+                  ${hooves}
+                </g>
+                <g class="cow-horns">
+                  <path d="${hornsLeft}" fill="${hornColour}" stroke="${darken(hornColour, 0.2)}" stroke-width="1.6" />
+                  <path d="${hornsRight}" fill="${hornColour}" stroke="${darken(hornColour, 0.2)}" stroke-width="1.6" />
+                  <path d="${hornHighlightLeft}" stroke="rgba(255,255,255,0.45)" stroke-width="1.4" stroke-linecap="round" fill="none" />
+                  <path d="${hornHighlightRight}" stroke="rgba(255,255,255,0.45)" stroke-width="1.4" stroke-linecap="round" fill="none" />
+                </g>
+                <g class="cow-ears">
+                  <path d="${earLeft}" fill="${earOuter}" stroke="${darken(earOuter, 0.12)}" stroke-width="1.2" />
+                  <path d="${earRight}" fill="${earOuter}" stroke="${darken(earOuter, 0.12)}" stroke-width="1.2" />
+                  <path d="${earInnerLeft}" fill="${earInner}" />
+                  <path d="${earInnerRight}" fill="${earInner}" />
+                </g>
+                <g class="cow-head">
+                  <ellipse cx="0" cy="${fmt(anatomy.head.centerY)}" rx="${fmt(anatomy.head.width / 2)}" ry="${fmt(anatomy.head.height / 2)}" fill="${fringeColour}" stroke="${fringeShadow}" stroke-width="1.4" />
+                  <path class="cow-fringe-layer" d="${fringeLayers[0]}" fill="${fringeColour}" stroke="${darken(fringeShadow, 0.1)}" stroke-width="1.2" />
+                  <path class="cow-fringe-layer" d="${fringeLayers[1]}" fill="${fringeHighlight}" stroke="rgba(53,38,77,0.08)" stroke-width="1.2" />
+                  <path class="cow-fringe-layer" d="${fringeLayers[2]}" fill="${lighten(fringeColour, 0.28)}" stroke="rgba(53,38,77,0.08)" stroke-width="1" />
+                  <path class="cow-fringe-bang" d="${fringeBang}" fill="${fringeShadow}" />
+                </g>
+                <g class="cow-muzzle">
+                  <ellipse cx="0" cy="${fmt(anatomy.muzzle.y)}" rx="${fmt(anatomy.muzzle.width / 2)}" ry="${fmt(anatomy.muzzle.height / 2)}" fill="${muzzleColour}" stroke="${darken(muzzleColour, 0.28)}" stroke-width="1.2" />
+                  <ellipse cx="0" cy="${fmt(anatomy.muzzle.y - anatomy.muzzle.height * 0.2)}" rx="${fmt(anatomy.muzzle.width * 0.32)}" ry="${fmt(anatomy.muzzle.height * 0.26)}" fill="rgba(255,255,255,0.22)" />
+                  <ellipse cx="${fmt(-anatomy.muzzle.nostrilOffset)}" cy="${fmt(anatomy.muzzle.y + anatomy.muzzle.height * 0.04)}" rx="3.2" ry="4.6" fill="${nostrilColour}" />
+                  <ellipse cx="${fmt(anatomy.muzzle.nostrilOffset)}" cy="${fmt(anatomy.muzzle.y + anatomy.muzzle.height * 0.04)}" rx="3.2" ry="4.6" fill="${nostrilColour}" />
+                  <path d="${mouth}" stroke="${darken(nostrilColour, 0.1)}" stroke-width="1.6" stroke-linecap="round" fill="none" />
+                </g>
+                <g class="cow-eyes">
+                  <circle cx="${fmt(eyes.left)}" cy="${fmt(anatomy.eyes.y)}" r="${fmt(anatomy.eyes.radius)}" fill="#35264d" />
+                  <circle cx="${fmt(eyes.right)}" cy="${fmt(anatomy.eyes.y)}" r="${fmt(anatomy.eyes.radius)}" fill="#35264d" />
+                  <circle cx="${fmt(eyes.left - 1.2)}" cy="${fmt(anatomy.eyes.y - 1.4)}" r="${fmt(anatomy.eyes.radius * 0.35)}" fill="rgba(255,255,255,0.4)" />
+                  <circle cx="${fmt(eyes.right - 1.2)}" cy="${fmt(anatomy.eyes.y - 1.4)}" r="${fmt(anatomy.eyes.radius * 0.35)}" fill="rgba(255,255,255,0.4)" />
+                  ${sleepyLids}
+                  ${lashPaths}
+                </g>
+                ${cheeksGroup}
+                ${browGroup}
+                ${accessories}
+              </g>
             </g>
           </svg>`;
 }

--- a/highland-cow-farm/src/styles/theme.css
+++ b/highland-cow-farm/src/styles/theme.css
@@ -643,6 +643,26 @@
       transition: transform 0.4s ease;
     }
 
+    .cow-art .cow-root-group {
+      transform-box: fill-box;
+      transform-origin: 50% 72%;
+    }
+
+    .cow-art--idle-wobble .cow-root-group,
+    .cow-art .cow-root-group.is-idle-wobble {
+      animation: cowIdleWobble 4.2s ease-in-out infinite;
+    }
+
+    @keyframes cowIdleWobble {
+      0%,
+      100% {
+        transform: translateY(0);
+      }
+      50% {
+        transform: translateY(2.2px);
+      }
+    }
+
     .cow-card.is-chonk .cow-art {
       transform: scale(1.1) translateY(6px);
     }


### PR DESCRIPTION
## Summary
- compute detailed cow anatomy data to drive horns, ears, muzzle, hooves and layered fringe with shading and personality traits
- update accessory SVG/drawing helpers to use anatomy-aware transforms and clipping so hats, bows and garlands sit over the new fringe and horns
- add idle wobble toggles and supporting CSS animation hooks for the updated cow root group

## Testing
- npm run build *(fails: Vite missing because dependencies could not be installed — npm registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6aeed1408321bc4054fafdbc31f8