### PR TITLE
refactor cow visuals and pastel theme

### DIFF
--- a/highland-cow-farm/src/data/accessories.ts
+++ b/highland-cow-farm/src/data/accessories.ts
@@ -1,341 +1,64 @@
-import type { Cow } from '../types';
-import type { AccessoryRenderMeta, CowVisualOptions } from '../game/cowVisuals';
-
-const fmt = (value: number): string => (Number.isFinite(value) ? Number(value.toFixed(3)).toString() : '0');
-
-function withClip(ctx: CanvasRenderingContext2D, meta: AccessoryRenderMeta | undefined, draw: () => void) {
-  ctx.save();
-  if (meta?.clipAboveHead && meta.clipAboveHead.height > 0) {
-    ctx.beginPath();
-    ctx.rect(-220, meta.clipAboveHead.y, 440, meta.clipAboveHead.height);
-    ctx.clip();
-  }
-  draw();
-  ctx.restore();
-}
-
-function clipAttribute(meta: AccessoryRenderMeta | undefined): string {
-  return meta?.clipPathId ? ` clip-path="url(#${meta.clipPathId})"` : '';
-}
-
 export interface AccessoryEntry {
   icon: string;
   description: string;
-  svg?: (cow?: Cow, meta?: AccessoryRenderMeta) => string;
-  draw?: (ctx: CanvasRenderingContext2D, cow?: Cow, meta?: AccessoryRenderMeta & CowVisualOptions) => void;
+  aliasFor?: string;
 }
 
-export const AccessoryLibrary: Record<string, AccessoryEntry> = {
-  'Pastel Bow': {
+const baseAccessories: Record<string, AccessoryEntry> = {
+  bow_pink: {
     icon: '🎀',
-    description: 'A soft ribbon tied neatly near the fringe.',
-    svg: (_cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const x = anatomy ? -anatomy.head.width * 0.36 : -20;
-      const y = anatomy ? anatomy.horns.baseY + anatomy.horns.thickness * 1.1 : -18;
-      return `
-          <g class="acc acc-bow"${clipAttribute(meta)} transform="translate(${fmt(x)} ${fmt(y)})">
-            <ellipse cx="-6" cy="-2" rx="6" ry="8" fill="#f7c1d8" />
-            <ellipse cx="6" cy="-2" rx="6" ry="8" fill="#f7c1d8" />
-            <circle cx="0" cy="-2" r="3.4" fill="#f38aad" />
-          </g>`;
-    },
-    draw: (ctx, _cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const x = anatomy ? -anatomy.head.width * 0.36 : -20;
-      const y = anatomy ? anatomy.horns.baseY + anatomy.horns.thickness * 1.1 : -18;
-      withClip(ctx, meta, () => {
-        ctx.translate(x, y);
-        ctx.fillStyle = '#f7c1d8';
-        ctx.beginPath();
-        ctx.ellipse(-6, -2, 6, 8, 0, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.beginPath();
-        ctx.ellipse(6, -2, 6, 8, 0, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.fillStyle = '#f38aad';
-        ctx.beginPath();
-        ctx.arc(0, -2, 3.4, 0, Math.PI * 2);
-        ctx.fill();
-      });
-    }
+    description: 'Bubblegum ribbon pinned beside the fringe.'
   },
-  'Bell Charm': {
-    icon: '🔔',
-    description: 'A gentle bell that jingles as the cow trots.',
-    svg: (_cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.95 : 14;
-      return `
-          <g class="acc acc-bell" transform="translate(0,${fmt(y)})">
-            <path d="M-6 0 Q0 -8 6 0 V4 H-6 Z" fill="#f4d38b" stroke="#d6a442" stroke-width="1" />
-            <circle cx="0" cy="3" r="1.8" fill="#d6a442" />
-          </g>`;
-    },
-    draw: (ctx, _cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.95 : 14;
-      ctx.save();
-      ctx.translate(0, y);
-      ctx.beginPath();
-      ctx.moveTo(-6, 0);
-      ctx.quadraticCurveTo(0, -8, 6, 0);
-      ctx.lineTo(6, 4);
-      ctx.lineTo(-6, 4);
-      ctx.closePath();
-      ctx.fillStyle = '#f4d38b';
-      ctx.fill();
-      ctx.lineWidth = 1.2;
-      ctx.strokeStyle = '#d6a442';
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.fillStyle = '#d6a442';
-      ctx.arc(0, 3, 1.8, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.restore();
-    }
-  },
-  'Sun Hat': {
+  sun_hat: {
     icon: '👒',
-    description: 'A straw hat to keep the Highland sun at bay.',
-    svg: (_cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.horns.tipY + anatomy.horns.thickness * 0.6 : -34;
-      const scaleX = anatomy ? anatomy.head.width / 56 : 1;
-      const transform = `translate(0,${fmt(y)})${scaleX !== 1 ? ` scale(${fmt(scaleX)} 1)` : ''}`;
-      return `
-          <g class="acc acc-hat"${clipAttribute(meta)} transform="${transform}">
-            <ellipse cx="0" cy="0" rx="28" ry="10" fill="#f3d9a4" stroke="#d6a067" stroke-width="1.4" />
-            <ellipse cx="0" cy="-6" rx="18" ry="10" fill="#f8e7bf" stroke="#d6a067" stroke-width="1.2" />
-            <path d="M-12 -4 Q0 -10 12 -4" stroke="#f2a9b7" stroke-width="3" fill="none" />
-          </g>`;
-    },
-    draw: (ctx, _cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.horns.tipY + anatomy.horns.thickness * 0.6 : -34;
-      const scaleX = anatomy ? anatomy.head.width / 56 : 1;
-      withClip(ctx, meta, () => {
-        ctx.translate(0, y);
-        if (scaleX !== 1) {
-          ctx.scale(scaleX, 1);
-        }
-        ctx.fillStyle = '#f3d9a4';
-        ctx.strokeStyle = '#d6a067';
-        ctx.lineWidth = 1.4;
-        ctx.beginPath();
-        ctx.ellipse(0, 0, 28, 10, 0, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.stroke();
-        ctx.fillStyle = '#f8e7bf';
-        ctx.lineWidth = 1.2;
-        ctx.beginPath();
-        ctx.ellipse(0, -6, 18, 10, 0, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.stroke();
-        ctx.beginPath();
-        ctx.strokeStyle = '#f2a9b7';
-        ctx.lineWidth = 3;
-        ctx.moveTo(-12, -4);
-        ctx.quadraticCurveTo(0, -10, 12, -4);
-        ctx.stroke();
-      });
-    }
+    description: 'Straw sun hat with a pink band for bright paddock days.'
   },
-  'Fern Garland': {
-    icon: '🌿',
-    description: 'Braided fern fronds draped across the horns.',
-    svg: (_cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.horns.baseY + anatomy.horns.thickness * 0.4 : -18;
-      const scaleX = anatomy ? anatomy.horns.outerSpread / 34 : 1;
-      const transform = `translate(0,${fmt(y)})${scaleX !== 1 ? ` scale(${fmt(scaleX)} 1)` : ''}`;
-      return `
-          <g class="acc acc-fern"${clipAttribute(meta)} transform="${transform}">
-            <path d="M-34 -4 Q-12 -12 0 -6 T34 -4" fill="none" stroke="#7fb991" stroke-width="4" stroke-linecap="round" />
-            <path d="M-24 -6 l-3 -6 l5 2 z" fill="#6aa67d" />
-            <path d="M-12 -10 l-3 -6 l5 2 z" fill="#6aa67d" />
-            <path d="M12 -10 l3 -6 l-5 2 z" fill="#6aa67d" />
-            <path d="M24 -6 l3 -6 l-5 2 z" fill="#6aa67d" />
-          </g>`;
-    },
-    draw: (ctx, _cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.horns.baseY + anatomy.horns.thickness * 0.4 : -18;
-      const scaleX = anatomy ? anatomy.horns.outerSpread / 34 : 1;
-      withClip(ctx, meta, () => {
-        ctx.translate(0, y);
-        if (scaleX !== 1) {
-          ctx.scale(scaleX, 1);
-        }
-        ctx.strokeStyle = '#7fb991';
-        ctx.lineWidth = 4;
-        ctx.lineCap = 'round';
-        ctx.beginPath();
-        ctx.moveTo(-34, -4);
-        ctx.quadraticCurveTo(-12, -12, 0, -6);
-        ctx.quadraticCurveTo(12, -0, 34, -4);
-        ctx.stroke();
-        ctx.fillStyle = '#6aa67d';
-        const leaves = [
-          { x: -24, y: -6 },
-          { x: -12, y: -10 },
-          { x: 12, y: -10 },
-          { x: 24, y: -6 }
-        ];
-        leaves.forEach(({ x, y }) => {
-          ctx.beginPath();
-          ctx.moveTo(x, y);
-          ctx.lineTo(x - 3, y - 6);
-          ctx.lineTo(x + 2, y - 4);
-          ctx.closePath();
-          ctx.fill();
-        });
-      });
-    }
-  },
-  'Starry Bandana': {
-    icon: '🧣',
-    description: 'A midnight blue bandana dotted with stars.',
-    svg: (_cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.55 : 12;
-      const scaleX = anatomy ? anatomy.head.width / 44 : 1;
-      const transform = `translate(0,${fmt(y)})${scaleX !== 1 ? ` scale(${fmt(scaleX)} 1)` : ''}`;
-      return `
-          <g class="acc acc-bandana" transform="${transform}">
-            <path d="M-22 -2 L0 10 L22 -2 Z" fill="#3b3b7d" stroke="#272757" stroke-width="1.2" />
-            <circle cx="-10" cy="2" r="1.5" fill="#f7e27d" />
-            <circle cx="0" cy="4" r="1.2" fill="#f7e27d" />
-            <circle cx="10" cy="2" r="1.5" fill="#f7e27d" />
-          </g>`;
-    },
-    draw: (ctx, _cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.55 : 12;
-      const scaleX = anatomy ? anatomy.head.width / 44 : 1;
-      ctx.save();
-      ctx.translate(0, y);
-      if (scaleX !== 1) {
-        ctx.scale(scaleX, 1);
-      }
-      ctx.beginPath();
-      ctx.moveTo(-22, -2);
-      ctx.lineTo(0, 10);
-      ctx.lineTo(22, -2);
-      ctx.closePath();
-      ctx.fillStyle = '#3b3b7d';
-      ctx.fill();
-      ctx.lineWidth = 1.2;
-      ctx.strokeStyle = '#272757';
-      ctx.stroke();
-      ctx.fillStyle = '#f7e27d';
-      [[-10, 2, 1.5], [0, 4, 1.2], [10, 2, 1.5]].forEach(([x, y, r]) => {
-        ctx.beginPath();
-        ctx.arc(x as number, y as number, r as number, 0, Math.PI * 2);
-        ctx.fill();
-      });
-      ctx.restore();
-    }
-  },
-  'Woolly Scarf': {
-    icon: '🧶',
-    description: 'A cosy knitted scarf for brisk mornings.',
-    svg: (_cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.82 : 18;
-      const scaleX = anatomy ? anatomy.head.width / 52 : 1;
-      const transform = `translate(0,${fmt(y)})${scaleX !== 1 ? ` scale(${fmt(scaleX)} 1)` : ''}`;
-      return `
-          <g class="acc acc-scarf" transform="${transform}">
-            <path d="M-26 -6 Q0 6 26 -6 L22 6 Q0 16 -22 6 Z" fill="#f2a9b7" stroke="#c97a8a" stroke-width="1.2" />
-            <path d="M-6 -4 V12" stroke="#c97a8a" stroke-width="3" stroke-linecap="round" />
-            <path d="M6 -4 V12" stroke="#c97a8a" stroke-width="3" stroke-linecap="round" />
-          </g>`;
-    },
-    draw: (ctx, _cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.muzzle.y + anatomy.muzzle.height * 0.82 : 18;
-      const scaleX = anatomy ? anatomy.head.width / 52 : 1;
-      ctx.save();
-      ctx.translate(0, y);
-      if (scaleX !== 1) {
-        ctx.scale(scaleX, 1);
-      }
-      ctx.beginPath();
-      ctx.moveTo(-26, -6);
-      ctx.quadraticCurveTo(0, 6, 26, -6);
-      ctx.lineTo(22, 6);
-      ctx.quadraticCurveTo(0, 16, -22, 6);
-      ctx.closePath();
-      ctx.fillStyle = '#f2a9b7';
-      ctx.fill();
-      ctx.lineWidth = 1.2;
-      ctx.strokeStyle = '#c97a8a';
-      ctx.stroke();
-      ctx.lineWidth = 3;
-      ctx.lineCap = 'round';
-      ctx.beginPath();
-      ctx.moveTo(-6, -4);
-      ctx.lineTo(-6, 12);
-      ctx.moveTo(6, -4);
-      ctx.lineTo(6, 12);
-      ctx.stroke();
-      ctx.restore();
-    }
-  },
-  'Thistle Crown': {
+  flower_crown: {
     icon: '🌸',
-    description: 'Highland thistles woven into a proud little crown.',
-    svg: (_cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.horns.baseY - anatomy.horns.thickness * 0.2 : -26;
-      const scaleX = anatomy ? anatomy.horns.outerSpread / 26 : 1;
-      const transform = `translate(0,${fmt(y)})${scaleX !== 1 ? ` scale(${fmt(scaleX)} 1)` : ''}`;
-      return `
-          <g class="acc acc-thistle"${clipAttribute(meta)} transform="${transform}">
-            <path d="M-26 -4 Q0 -10 26 -4" fill="none" stroke="#7fb991" stroke-width="3" stroke-linecap="round" />
-            <circle cx="-16" cy="-8" r="4" fill="#c181d8" />
-            <circle cx="0" cy="-12" r="4.5" fill="#b56ccc" />
-            <circle cx="16" cy="-8" r="4" fill="#c181d8" />
-            <path d="M-16 -8 l-2 -6" stroke="#7fb991" stroke-width="2" />
-            <path d="M0 -12 l-2 -6" stroke="#7fb991" stroke-width="2" />
-            <path d="M16 -8 l2 -6" stroke="#7fb991" stroke-width="2" />
-          </g>`;
-    },
-    draw: (ctx, _cow, meta) => {
-      const anatomy = meta?.anatomy;
-      const y = anatomy ? anatomy.horns.baseY - anatomy.horns.thickness * 0.2 : -26;
-      const scaleX = anatomy ? anatomy.horns.outerSpread / 26 : 1;
-      withClip(ctx, meta, () => {
-        ctx.translate(0, y);
-        if (scaleX !== 1) {
-          ctx.scale(scaleX, 1);
-        }
-        ctx.strokeStyle = '#7fb991';
-        ctx.lineWidth = 3;
-        ctx.lineCap = 'round';
-        ctx.beginPath();
-        ctx.moveTo(-26, -4);
-        ctx.quadraticCurveTo(0, -10, 26, -4);
-        ctx.stroke();
-        const blooms = [
-          { x: -16, y: -8, r: 4, colour: '#c181d8' },
-          { x: 0, y: -12, r: 4.5, colour: '#b56ccc' },
-          { x: 16, y: -8, r: 4, colour: '#c181d8' }
-        ];
-        blooms.forEach(({ x, y, r, colour }) => {
-          ctx.beginPath();
-          ctx.fillStyle = colour;
-          ctx.arc(x, y, r, 0, Math.PI * 2);
-          ctx.fill();
-          ctx.beginPath();
-          ctx.lineWidth = 2;
-          ctx.moveTo(x, y);
-          ctx.lineTo(x + (x === 0 ? -2 : Math.sign(x) * -2), y - 6);
-          ctx.strokeStyle = '#7fb991';
-          ctx.stroke();
-        });
-      });
-    }
+    description: 'Pastel daisies, cosmos and forget-me-nots woven together.'
+  },
+  bell_charm: {
+    icon: '🔔',
+    description: 'Polished bell with a silky ribbon that chimes softly.'
+  },
+  fern_garland: {
+    icon: '🌿',
+    description: 'Fern sprigs tucked gracefully along the horns.'
+  },
+  starry_bandana: {
+    icon: '🧣',
+    description: 'Midnight bandana speckled with friendly constellations.'
+  },
+  woolly_scarf: {
+    icon: '🧶',
+    description: 'Chunky-knit scarf for crisp Highland mornings.'
   }
 };
+
+const aliasEntries: Record<string, AccessoryEntry> = {
+  'Pastel Bow': { ...baseAccessories.bow_pink, aliasFor: 'bow_pink' },
+  'Sun Hat': { ...baseAccessories.sun_hat, aliasFor: 'sun_hat' },
+  'Flower Crown': { ...baseAccessories.flower_crown, aliasFor: 'flower_crown' },
+  'Thistle Crown': { ...baseAccessories.flower_crown, aliasFor: 'flower_crown' },
+  'Bell Charm': { ...baseAccessories.bell_charm, aliasFor: 'bell_charm' },
+  'Fern Garland': { ...baseAccessories.fern_garland, aliasFor: 'fern_garland' },
+  'Starry Bandana': { ...baseAccessories.starry_bandana, aliasFor: 'starry_bandana' },
+  'Woolly Scarf': { ...baseAccessories.woolly_scarf, aliasFor: 'woolly_scarf' }
+};
+
+export const AccessoryLibrary: Record<string, AccessoryEntry> = {
+  ...baseAccessories,
+  ...aliasEntries
+};
+
+export type AccessoryName = keyof typeof AccessoryLibrary;
+
+export function resolvedAccessoryKey(name: string): string {
+  const entry = AccessoryLibrary[name];
+  if (!entry) return name;
+  return entry.aliasFor ?? name;
+}
+
+export function listAccessories(): string[] {
+  return Object.keys(AccessoryLibrary);
+}

--- a/highland-cow-farm/src/game/cowVisuals.ts
+++ b/highland-cow-farm/src/game/cowVisuals.ts
@@ -1,796 +1,1306 @@
 import type { Cow } from '../types';
-import { AccessoryLibrary } from '../data/accessories';
 
-export interface CowVisualOptions {
-  scale?: number;
-  offsetY?: number;
-  wobble?: number;
-  x?: number;
-  y?: number;
-  rotation?: number;
-  className?: string;
-  viewBox?: string;
-  traits?: Partial<CowTraits>;
-  animations?: {
-    idleWobble?: boolean;
-  };
-}
-
-export interface CowTraits {
-  sleepyEyes: boolean;
-  rosyCheeks: boolean;
-  fancyLashes: boolean;
-  raisedBrow: boolean;
-}
-
-export interface CowAnatomy {
-  body: {
-    centerY: number;
-    rx: number;
-    ry: number;
-    highlightRx: number;
-    highlightRy: number;
-  };
-  head: {
-    width: number;
-    height: number;
-    centerY: number;
-  };
-  horns: {
-    baseY: number;
-    tipY: number;
-    innerSpread: number;
-    outerSpread: number;
-    thickness: number;
-  };
-  ears: {
-    baseY: number;
-    width: number;
-    height: number;
-    tilt: number;
-  };
-  muzzle: {
-    y: number;
-    width: number;
-    height: number;
-    nostrilOffset: number;
-  };
-  hooves: {
-    y: number;
-    width: number;
-    height: number;
-    spacing: number;
-  };
-  eyes: {
-    y: number;
-    spacing: number;
-    radius: number;
-  };
-  cheeks: {
-    y: number;
-    spacing: number;
-    radius: number;
-  };
-  fringe: {
-    layers: Array<{ width: number; height: number; offsetY: number }>;
-    swoopDepth: number;
-    bangDepth: number;
-  };
-}
-
-interface CowScaleMeta {
-  scale: number;
-  bellyOffset: number;
-  bellyStretch: number;
-  chonkBoost: number;
-  anatomy: CowAnatomy;
-}
-
-export interface AccessoryRenderMeta {
-  anatomy: CowAnatomy;
-  clipAboveHead: { y: number; height: number };
-  clipPathId?: string;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
-
-function hexToRgb(hex: string): { r: number; g: number; b: number } {
-  const normalized = hex.replace('#', '');
-  const bigint = parseInt(normalized, 16);
-  return {
-    r: (bigint >> 16) & 255,
-    g: (bigint >> 8) & 255,
-    b: bigint & 255
-  };
-}
-
-function mixColour(base: string, withColour: string, amount: number): string {
-  const a = hexToRgb(base);
-  const b = hexToRgb(withColour);
-  const r = Math.round(a.r + (b.r - a.r) * amount);
-  const g = Math.round(a.g + (b.g - a.g) * amount);
-  const bl = Math.round(a.b + (b.b - a.b) * amount);
-  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${bl.toString(16).padStart(2, '0')}`;
-}
-
-function lighten(colour: string, amount: number): string {
-  return mixColour(colour, '#ffffff', clamp(amount, 0, 1));
-}
-
-function darken(colour: string, amount: number): string {
-  return mixColour(colour, '#000000', clamp(amount, 0, 1));
-}
-
-function toKebabCase(value: string): string {
-  return value.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
-}
-
-function fmt(value: number): string {
-  return Number.isFinite(value) ? Number(value.toFixed(3)).toString() : '0';
-}
-
-const colourMap: Record<string, string> = {
-  brown: '#c99364',
-  cream: '#f7e5c6',
-  rose: '#f5c0c8',
-  chocolate: '#a4744b',
-  white: '#fefefe'
+export const COAT_COLOURS: Record<Cow['colour'], { base: string; shade: string; light: string }> = {
+  brown: { base: '#C98655', shade: '#B37447', light: '#E2AA7C' },
+  cream: { base: '#E9D6B8', shade: '#D2BE9F', light: '#F5E8D3' },
+  rose: { base: '#F2B7C6', shade: '#DD9DAF', light: '#FFD7E3' },
+  chocolate: { base: '#8A5A3B', shade: '#72482F', light: '#A87553' },
+  white: { base: '#F3F1EA', shade: '#D4D1C7', light: '#FFFFFF' }
 };
 
-export function colourHex(colour: string): string {
-  return colourMap[colour] || colourMap.brown;
+const EYE_COLOUR = '#4A2C3A';
+const BLUSH_COLOUR = '#F3B1B4';
+const HORN_BASE = '#D7CFC4';
+
+export type CowPose = 'idle' | 'walk' | 'blink';
+
+export interface CowSvgOptions {
+  size?: number;
+  pose?: CowPose;
+  highContrast?: boolean;
+  className?: string;
+  scale?: number;
+  viewBox?: string;
+  offsetX?: number;
+  offsetY?: number;
 }
 
-function accessoriesSVG(cow: Cow, meta: AccessoryRenderMeta): string {
-  return (cow.accessories || [])
-    .map(name => {
-      const entry = AccessoryLibrary[name];
-      return entry && typeof entry.svg === 'function' ? entry.svg(cow, meta) : '';
+export interface CowCanvasOptions {
+  w?: number;
+  h?: number;
+  pose?: CowPose;
+}
+
+interface LegGeometry {
+  side: 'left' | 'right';
+  position: 'front' | 'back';
+  x: number;
+  top: number;
+  bottom: number;
+  width: number;
+  hoofWidth: number;
+  hoofHeight: number;
+  lift: number;
+}
+
+interface CowGeometry {
+  pose: CowPose;
+  chonk: number;
+  bobStrength: number;
+  body: {
+    cx: number;
+    cy: number;
+    rx: number;
+    ry: number;
+    bellyRx: number;
+    bellyRy: number;
+    bellyCy: number;
+  };
+  head: {
+    cx: number;
+    cy: number;
+    rx: number;
+    ry: number;
+    top: number;
+    bottom: number;
+  };
+  snout: {
+    cx: number;
+    cy: number;
+    width: number;
+    height: number;
+    nostrilGap: number;
+    nostrilRadius: number;
+  };
+  horns: {
+    baseLeft: { x: number; y: number };
+    baseRight: { x: number; y: number };
+    tipLeft: { x: number; y: number };
+    tipRight: { x: number; y: number };
+    innerLeft: { x: number; y: number };
+    innerRight: { x: number; y: number };
+  };
+  ears: {
+    left: { x: number; y: number; width: number; height: number; tilt: number };
+    right: { x: number; y: number; width: number; height: number; tilt: number };
+  };
+  eyes: {
+    left: { cx: number; cy: number; rx: number; ry: number };
+    right: { cx: number; cy: number; rx: number; ry: number };
+  };
+  blush: {
+    left: { cx: number; cy: number; rx: number; ry: number };
+    right: { cx: number; cy: number; rx: number; ry: number };
+  };
+  fringe: {
+    top: number;
+    bottom: number;
+    width: number;
+  };
+  legs: LegGeometry[];
+  crown: {
+    y: number;
+    radius: number;
+  };
+}
+
+interface AccessoryGeometry {
+  cow: Cow;
+  geo: CowGeometry;
+  scale: number;
+}
+
+type AccessoryRenderer = {
+  svg: (input: AccessoryGeometry) => string;
+  canvas?: (ctx: CanvasRenderingContext2D, input: AccessoryGeometry) => void;
+};
+
+const DEFAULT_SIZE = 240;
+const DEFAULT_VIEWBOX = { x: -120, y: -120, width: 240, height: 240 } as const;
+
+interface ViewBoxDefinition {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const BLUSH_MIN_OPACITY = 0.35;
+const BLUSH_MAX_OPACITY = 0.5;
+
+const BLINK_DURATION = 180;
+const BLINK_GAP_MIN = 2800;
+const BLINK_GAP_MAX = 6200;
+
+const blinkControllers = new WeakMap<HTMLElement, { open?: number; close?: number }>();
+
+const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+const fmt = (value: number): string => Number.isFinite(value) ? Number(value.toFixed(2)).toString() : '0';
+const now = (): number => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+let gradientCounter = 0;
+const uid = (prefix: string): string => `${prefix}-${(++gradientCounter).toString(36)}`;
+
+function parseViewBox(value?: string): ViewBoxDefinition | null {
+  if (!value) return null;
+  const parts = value.trim().split(/[\s,]+/).map(part => Number(part));
+  if (parts.length !== 4 || parts.some(part => Number.isNaN(part))) {
+    return null;
+  }
+  const [x, y, width, height] = parts;
+  return { x, y, width, height };
+}
+
+export function colourHex(colour: Cow['colour']): string {
+  return (COAT_COLOURS[colour] || COAT_COLOURS.brown).base;
+}
+
+const normaliseAccessoryName = (name: string): string => name.trim().toLowerCase().replace(/\s+/g, '_');
+
+function chonkBucket(chonk: number): number {
+  const normalised = clamp(chonk, 0, 100);
+  return Math.min(4, Math.floor(normalised / 25));
+}
+
+function computeGeometry(cow: Cow, pose: CowPose, timestamp: number = now()): CowGeometry {
+  const chonk = clamp(cow.chonk ?? 0, 0, 100) / 100;
+  const effectivePose = pose === 'blink' ? 'idle' : pose;
+  const bobStrength = 1 - chonk * 0.45;
+  const baseBob = effectivePose === 'walk' ? 4.2 : 1.6;
+  const bob = Math.sin(timestamp / (effectivePose === 'walk' ? 380 : 920)) * baseBob * bobStrength;
+  const sway = Math.cos(timestamp / 1450) * 1.1;
+
+  const baseBodyCy = 44;
+  const baseBodyRx = 80;
+  const baseBodyRy = 54;
+  const bodyRx = baseBodyRx * (1 + 0.15 * chonk);
+  const bodyRy = baseBodyRy * (1 + 0.12 * chonk);
+  const bodyCy = baseBodyCy + bob * 0.6;
+
+  const bellyRx = 50 + 22 * chonk;
+  const bellyRy = 32 + 16 * chonk;
+  const bellyCy = bodyCy + bodyRy * 0.2;
+
+  const baseHeadCy = -32;
+  const headRx = 58;
+  const headRy = 52;
+  const headCy = baseHeadCy + bob;
+  const headTop = headCy - headRy;
+  const headBottom = headCy + headRy;
+
+  const snoutCy = headCy + headRy * 0.26;
+  const snoutWidth = 62;
+  const snoutHeight = 42;
+
+  const hornsBaseY = headTop + 18;
+  const hornOffsetX = headRx * 0.64;
+  const hornTipOffsetX = hornOffsetX + 46;
+  const hornTipOffsetY = 36;
+
+  const eyesSpacing = 42;
+  const eyeRx = 12.5;
+  const eyeRy = 14;
+  const eyeCy = headCy - headRy * 0.18;
+
+  const blushCy = snoutCy + 12;
+  const blushRx = 20;
+  const blushRy = 13;
+
+  const legBaseY = bodyCy + bodyRy - 6;
+  const legHeight = 46 + chonk * 8;
+  const legWidth = 24 + chonk * 5;
+  const hoofHeight = 12 + chonk * 4;
+  const hoofWidth = legWidth * 0.78;
+
+  const stepPhase = Math.sin(timestamp / 420);
+  const stepAmplitude = 6.2 * bobStrength;
+  const frontLift = effectivePose === 'walk' ? stepPhase * stepAmplitude : 0;
+  const backLift = effectivePose === 'walk' ? -stepPhase * stepAmplitude : 0;
+  const frontSpacing = bodyRx * 0.5 + 6;
+  const backSpacing = bodyRx * 0.26 + 4;
+
+  const legs: LegGeometry[] = [
+    {
+      side: 'left',
+      position: 'front',
+      x: -frontSpacing,
+      top: legBaseY - legHeight - Math.max(0, frontLift),
+      bottom: legBaseY + Math.max(0, -frontLift * 0.4),
+      width: legWidth,
+      hoofHeight,
+      hoofWidth,
+      lift: Math.max(0, frontLift)
+    },
+    {
+      side: 'right',
+      position: 'front',
+      x: frontSpacing,
+      top: legBaseY - legHeight - Math.max(0, -frontLift),
+      bottom: legBaseY + Math.max(0, frontLift * 0.4),
+      width: legWidth,
+      hoofHeight,
+      hoofWidth,
+      lift: Math.max(0, -frontLift)
+    },
+    {
+      side: 'left',
+      position: 'back',
+      x: -backSpacing,
+      top: legBaseY - legHeight - Math.max(0, backLift),
+      bottom: legBaseY + Math.max(0, -backLift * 0.4),
+      width: legWidth * 0.92,
+      hoofHeight,
+      hoofWidth: hoofWidth * 0.92,
+      lift: Math.max(0, backLift)
+    },
+    {
+      side: 'right',
+      position: 'back',
+      x: backSpacing,
+      top: legBaseY - legHeight - Math.max(0, -backLift),
+      bottom: legBaseY + Math.max(0, backLift * 0.4),
+      width: legWidth * 0.92,
+      hoofHeight,
+      hoofWidth: hoofWidth * 0.92,
+      lift: Math.max(0, -backLift)
+    }
+  ];
+
+  return {
+    pose,
+    chonk,
+    bobStrength,
+    body: {
+      cx: 0,
+      cy: bodyCy,
+      rx: bodyRx,
+      ry: bodyRy,
+      bellyRx,
+      bellyRy,
+      bellyCy
+    },
+    head: {
+      cx: 0,
+      cy: headCy,
+      rx: headRx,
+      ry: headRy,
+      top: headTop,
+      bottom: headBottom
+    },
+    snout: {
+      cx: 0,
+      cy: snoutCy,
+      width: snoutWidth,
+      height: snoutHeight,
+      nostrilGap: 18,
+      nostrilRadius: 6
+    },
+    horns: {
+      baseLeft: { x: -hornOffsetX, y: hornsBaseY },
+      baseRight: { x: hornOffsetX, y: hornsBaseY },
+      tipLeft: { x: -hornTipOffsetX, y: hornsBaseY - hornTipOffsetY },
+      tipRight: { x: hornTipOffsetX, y: hornsBaseY - hornTipOffsetY },
+      innerLeft: { x: -hornOffsetX + 6, y: hornsBaseY - 18 },
+      innerRight: { x: hornOffsetX - 6, y: hornsBaseY - 18 }
+    },
+    ears: {
+      left: { x: -headRx * 0.78, y: headCy - headRy * 0.32, width: 34, height: 38, tilt: -12 + sway },
+      right: { x: headRx * 0.78, y: headCy - headRy * 0.32, width: 34, height: 38, tilt: 12 + sway }
+    },
+    eyes: {
+      left: { cx: -eyesSpacing / 2, cy: eyeCy, rx: eyeRx, ry: eyeRy },
+      right: { cx: eyesSpacing / 2, cy: eyeCy, rx: eyeRx, ry: eyeRy }
+    },
+    blush: {
+      left: { cx: -snoutWidth * 0.38, cy: blushCy, rx: blushRx, ry: blushRy },
+      right: { cx: snoutWidth * 0.38, cy: blushCy, rx: blushRx, ry: blushRy }
+    },
+    fringe: {
+      top: headTop + 6,
+      bottom: eyeCy + 16,
+      width: headRx * 1.46
+    },
+    legs,
+    crown: {
+      y: headTop + 14,
+      radius: headRx * 0.98
+    }
+  };
+}
+
+function buildLegPath(leg: LegGeometry): string {
+  const half = leg.width / 2;
+  const top = leg.top;
+  const knee = lerp(leg.top, leg.bottom - leg.hoofHeight, 0.55);
+  const bottom = leg.bottom;
+  const inset = leg.side === 'left' ? -2.2 : 2.2;
+  return `M ${fmt(leg.x - half)} ${fmt(top)} C ${fmt(leg.x - half - 6)} ${fmt(top + 14)}, ${fmt(leg.x - half + inset)} ${fmt(knee - 6)}, ${fmt(leg.x - half + 3)} ${fmt(knee)} ` +
+    `L ${fmt(leg.x - half + 4)} ${fmt(bottom - leg.hoofHeight)} C ${fmt(leg.x - half + 6)} ${fmt(bottom - 2)}, ${fmt(leg.x - half + 10)} ${fmt(bottom)}, ${fmt(leg.x - half + 16)} ${fmt(bottom)} ` +
+    `L ${fmt(leg.x + half - 16)} ${fmt(bottom)} C ${fmt(leg.x + half - 10)} ${fmt(bottom)}, ${fmt(leg.x + half - 6)} ${fmt(bottom - 2)}, ${fmt(leg.x + half - 4)} ${fmt(bottom - leg.hoofHeight)} ` +
+    `L ${fmt(leg.x + half - 3)} ${fmt(knee)} C ${fmt(leg.x + half - inset)} ${fmt(knee - 6)}, ${fmt(leg.x + half + 6)} ${fmt(top + 14)}, ${fmt(leg.x + half)} ${fmt(top)} Z`;
+}
+
+function buildHoofPath(leg: LegGeometry): string {
+  const half = leg.hoofWidth / 2;
+  const bottom = leg.bottom;
+  return `M ${fmt(leg.x - half)} ${fmt(bottom - leg.hoofHeight + 2)} Q ${fmt(leg.x)} ${fmt(bottom + 4)}, ${fmt(leg.x + half)} ${fmt(bottom - leg.hoofHeight + 2)} ` +
+    `Q ${fmt(leg.x)} ${fmt(bottom - leg.hoofHeight - 2)}, ${fmt(leg.x - half)} ${fmt(bottom - leg.hoofHeight + 2)} Z`;
+}
+
+function buildHornPath(geo: CowGeometry, side: 'left' | 'right'): string {
+  const start = side === 'left' ? geo.horns.baseLeft : geo.horns.baseRight;
+  const tip = side === 'left' ? geo.horns.tipLeft : geo.horns.tipRight;
+  const inner = side === 'left' ? geo.horns.innerLeft : geo.horns.innerRight;
+  const sweep = side === 'left' ? -1 : 1;
+  const curveOutX = start.x + sweep * 18;
+  const curveOutY = start.y - 18;
+  const midX = tip.x + sweep * 8;
+  const midY = tip.y + 8;
+  const returnX = start.x + sweep * 10;
+  const returnY = start.y + 14;
+  return `M ${fmt(start.x)} ${fmt(start.y)} C ${fmt(curveOutX)} ${fmt(curveOutY)}, ${fmt(midX)} ${fmt(midY)}, ${fmt(tip.x)} ${fmt(tip.y)} ` +
+    `Q ${fmt(tip.x + sweep * 14)} ${fmt(tip.y + 18)}, ${fmt(tip.x + sweep * 18)} ${fmt(tip.y + 32)} ` +
+    `C ${fmt(tip.x + sweep * 20)} ${fmt(tip.y + 44)}, ${fmt(returnX)} ${fmt(returnY)}, ${fmt(inner.x)} ${fmt(inner.y)} ` +
+    `Q ${fmt(start.x + sweep * 2)} ${fmt(start.y - 6)}, ${fmt(start.x)} ${fmt(start.y)} Z`;
+}
+
+function buildEarPath(ear: CowGeometry['ears']['left'], side: 'left' | 'right'): string {
+  const sweep = side === 'left' ? -1 : 1;
+  const tipX = ear.x + sweep * ear.width * 0.6;
+  const tipY = ear.y + ear.height * 0.1;
+  const bottomX = ear.x + sweep * ear.width * 0.2;
+  const bottomY = ear.y + ear.height;
+  return `M ${fmt(ear.x)} ${fmt(ear.y)} Q ${fmt(ear.x + sweep * ear.width * 0.4)} ${fmt(ear.y - ear.height * 0.2)}, ${fmt(tipX)} ${fmt(tipY)} ` +
+    `Q ${fmt(ear.x + sweep * ear.width * 0.9)} ${fmt(bottomY - ear.height * 0.15)}, ${fmt(bottomX)} ${fmt(bottomY)} ` +
+    `Q ${fmt(ear.x - sweep * ear.width * 0.2)} ${fmt(bottomY - ear.height * 0.1)}, ${fmt(ear.x)} ${fmt(ear.y)} Z`;
+}
+
+function buildEarInnerPath(ear: CowGeometry['ears']['left'], side: 'left' | 'right'): string {
+  const sweep = side === 'left' ? -1 : 1;
+  const tipX = ear.x + sweep * ear.width * 0.4;
+  const tipY = ear.y + ear.height * 0.12;
+  const bottomX = ear.x + sweep * ear.width * 0.12;
+  const bottomY = ear.y + ear.height * 0.76;
+  return `M ${fmt(ear.x + sweep * ear.width * 0.12)} ${fmt(ear.y + ear.height * 0.12)} Q ${fmt(ear.x + sweep * ear.width * 0.24)} ${fmt(ear.y - ear.height * 0.08)}, ${fmt(tipX)} ${fmt(tipY)} ` +
+    `Q ${fmt(ear.x + sweep * ear.width * 0.6)} ${fmt(bottomY - ear.height * 0.12)}, ${fmt(bottomX)} ${fmt(bottomY)} ` +
+    `Q ${fmt(ear.x)} ${fmt(bottomY - ear.height * 0.18)}, ${fmt(ear.x + sweep * ear.width * 0.12)} ${fmt(ear.y + ear.height * 0.12)} Z`;
+}
+
+function buildSnoutPath(geo: CowGeometry): string {
+  const left = geo.snout.cx - geo.snout.width / 2;
+  const right = geo.snout.cx + geo.snout.width / 2;
+  const top = geo.snout.cy - geo.snout.height * 0.52;
+  const bottom = geo.snout.cy + geo.snout.height * 0.68;
+  return `M ${fmt(left)} ${fmt(geo.snout.cy)} Q ${fmt(geo.snout.cx)} ${fmt(top)}, ${fmt(right)} ${fmt(geo.snout.cy)} ` +
+    `Q ${fmt(geo.snout.cx)} ${fmt(bottom)}, ${fmt(left)} ${fmt(geo.snout.cy)} Z`;
+}
+
+function buildSnoutHighlightPath(geo: CowGeometry): string {
+  const left = geo.snout.cx - geo.snout.width * 0.24;
+  const right = geo.snout.cx + geo.snout.width * 0.18;
+  const top = geo.snout.cy - geo.snout.height * 0.25;
+  const bottom = geo.snout.cy + geo.snout.height * 0.12;
+  return `M ${fmt(left)} ${fmt(geo.snout.cy)} Q ${fmt(geo.snout.cx - 4)} ${fmt(top)}, ${fmt(right)} ${fmt(geo.snout.cy - 4)} ` +
+    `Q ${fmt(geo.snout.cx - 2)} ${fmt(bottom)}, ${fmt(left)} ${fmt(geo.snout.cy)} Z`;
+}
+
+interface FringePaths {
+  back: string;
+  front: string;
+}
+
+function buildFringePaths(geo: CowGeometry): FringePaths {
+  const width = geo.fringe.width;
+  const left = -width / 2;
+  const top = geo.fringe.top;
+  const bottom = geo.fringe.bottom;
+  const tuftDepths = [0, 12, 5, 14, 6, 13, 4, 10];
+  const step = width / (tuftDepths.length - 1);
+  const right = left + width;
+
+  let back = `M ${fmt(left)} ${fmt(top)}`;
+  for (let i = 0; i < tuftDepths.length - 1; i++) {
+    const start = left + step * i;
+    const end = left + step * (i + 1);
+    const ctrlX = start + step / 2;
+    const ctrlY = top - (i % 2 === 0 ? 10 : 7);
+    back += ` Q ${fmt(ctrlX)} ${fmt(ctrlY)}, ${fmt(end)} ${fmt(top)}`;
+  }
+  back += ` L ${fmt(right)} ${fmt(bottom + tuftDepths[tuftDepths.length - 1])}`;
+  for (let i = tuftDepths.length - 2; i >= 0; i--) {
+    const drop = bottom + tuftDepths[i];
+    const endX = left + step * i;
+    const ctrlX = endX + step / 2;
+    const ctrlY = drop + (i % 2 === 0 ? 12 : 8);
+    back += ` Q ${fmt(ctrlX)} ${fmt(ctrlY)}, ${fmt(endX)} ${fmt(drop)}`;
+  }
+  back += ' Z';
+
+  const overlayWidth = width * 0.92;
+  const overlayLeft = -overlayWidth / 2;
+  const overlayTop = top + 3;
+  const overlayBottom = geo.eyes.left.cy - geo.eyes.left.ry * 0.25;
+  const overlayDepths = [0, 6, 2, 8, 3, 7, 1, 5];
+  const overlayStep = overlayWidth / (overlayDepths.length - 1);
+  const overlayRight = overlayLeft + overlayWidth;
+  let front = `M ${fmt(overlayLeft)} ${fmt(overlayTop)}`;
+  for (let i = 0; i < overlayDepths.length - 1; i++) {
+    const start = overlayLeft + overlayStep * i;
+    const end = overlayLeft + overlayStep * (i + 1);
+    const ctrlX = start + overlayStep / 2;
+    const ctrlY = overlayTop - (i % 2 === 0 ? 8 : 5);
+    front += ` Q ${fmt(ctrlX)} ${fmt(ctrlY)}, ${fmt(end)} ${fmt(overlayTop)}`;
+  }
+  front += ` L ${fmt(overlayRight)} ${fmt(overlayBottom + overlayDepths[overlayDepths.length - 1])}`;
+  for (let i = overlayDepths.length - 2; i >= 0; i--) {
+    const drop = overlayBottom + overlayDepths[i];
+    const endX = overlayLeft + overlayStep * i;
+    const ctrlX = endX + overlayStep / 2;
+    const ctrlY = drop + (i % 2 === 0 ? 7 : 9);
+    front += ` Q ${fmt(ctrlX)} ${fmt(ctrlY)}, ${fmt(endX)} ${fmt(drop)}`;
+  }
+  front += ' Z';
+
+  return { back, front };
+}
+
+function buildEyeHighlight(cx: number, cy: number): string {
+  return `M ${fmt(cx - 3)} ${fmt(cy - 4)} a 4 4 0 0 1 4 4  a 4 4 0 0 1 -4 -4`;
+}
+
+function buildEyeHalfPath(cx: number, cy: number, rx: number, ry: number): string {
+  return `M ${fmt(cx - rx)} ${fmt(cy)} Q ${fmt(cx)} ${fmt(cy - ry * 0.9)}, ${fmt(cx + rx)} ${fmt(cy)} L ${fmt(cx + rx)} ${fmt(cy + ry * 0.3)} ` +
+    `Q ${fmt(cx)} ${fmt(cy + ry * 0.1)}, ${fmt(cx - rx)} ${fmt(cy + ry * 0.3)} Z`;
+}
+
+function buildEyeClosedPath(cx: number, cy: number, rx: number): string {
+  return `M ${fmt(cx - rx)} ${fmt(cy)} Q ${fmt(cx)} ${fmt(cy + 1)}, ${fmt(cx + rx)} ${fmt(cy)}`;
+}
+
+function buildBrowPath(cx: number, cy: number, rx: number, tilt: number): string {
+  const leftX = cx - rx;
+  const rightX = cx + rx;
+  const arcY = cy - tilt;
+  return `M ${fmt(leftX)} ${fmt(cy)} Q ${fmt(cx)} ${fmt(arcY)}, ${fmt(rightX)} ${fmt(cy)}`;
+}
+
+function buildPastureGlow(geo: CowGeometry, gradientId: string): string {
+  const width = geo.body.rx * 1.6;
+  const height = geo.body.ry * 1.15;
+  return `<ellipse class='cow-backdrop' cx='0' cy='${fmt(geo.body.cy + geo.body.ry * 0.55)}' rx='${fmt(width)}' ry='${fmt(height)}' fill='url(#${gradientId})' />`;
+}
+
+function createDefs(geo: CowGeometry, coat: { base: string; shade: string; light: string }, highContrast: boolean) {
+  const bodyGradient = uid('coat');
+  const headGradient = uid('head');
+  const hornGradient = uid('horn');
+  const snoutGradient = uid('snout');
+  const glowGradient = uid('glow');
+  const defs = `<linearGradient id='${bodyGradient}' x1='0' y1='0' x2='0' y2='1'>
+      <stop offset='0%' stop-color='${coat.light}' />
+      <stop offset='65%' stop-color='${coat.base}' />
+      <stop offset='100%' stop-color='${coat.shade}' />
+    </linearGradient>
+    <linearGradient id='${headGradient}' x1='0' y1='0' x2='0' y2='1'>
+      <stop offset='0%' stop-color='${coat.light}' />
+      <stop offset='80%' stop-color='${coat.base}' />
+    </linearGradient>
+    <linearGradient id='${hornGradient}' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#F1EBE3' />
+      <stop offset='55%' stop-color='${HORN_BASE}' />
+      <stop offset='100%' stop-color='#BDAF9D' />
+    </linearGradient>
+    <linearGradient id='${snoutGradient}' x1='0' y1='0' x2='0' y2='1'>
+      <stop offset='0%' stop-color='${coat.light}' />
+      <stop offset='100%' stop-color='${coat.base}' />
+    </linearGradient>
+    <radialGradient id='${glowGradient}' cx='50%' cy='60%' r='62%'>
+      <stop offset='0%' stop-color='rgba(255, 246, 252, ${highContrast ? 0.9 : 0.75})' />
+      <stop offset='100%' stop-color='rgba(255, 246, 252, 0)' />
+    </radialGradient>`;
+  return { defs, bodyGradient, headGradient, hornGradient, snoutGradient, glowGradient };
+}
+
+const ACCESSORY_RENDERERS: Record<string, AccessoryRenderer> = {};
+
+function registerAccessories() {
+  if (Object.keys(ACCESSORY_RENDERERS).length) return;
+  ACCESSORY_RENDERERS.bow_pink = {
+    svg: ({ geo, scale }) => {
+      const x = geo.head.cx - geo.head.rx * 0.62;
+      const y = geo.head.cy - geo.head.ry * 0.08;
+      return `<g class="acc acc-bow" transform="translate(${fmt(x)} ${fmt(y)}) scale(${fmt(scale)})">
+          <ellipse cx="-10" cy="0" rx="10" ry="14" fill="#FBD5EA" />
+          <ellipse cx="10" cy="0" rx="10" ry="14" fill="#FBD5EA" />
+          <ellipse cx="0" cy="2" rx="6" ry="8" fill="#F49BC4" />
+          <path d="M-6 -12 Q0 -8 6 -12" fill="none" stroke="rgba(255,255,255,0.6)" stroke-width="2" stroke-linecap="round" />
+        </g>`;
+    },
+    canvas: (ctx, { geo, scale }) => {
+      const x = geo.head.cx - geo.head.rx * 0.62;
+      const y = geo.head.cy - geo.head.ry * 0.08;
+      ctx.save();
+      ctx.translate(x, y);
+      ctx.scale(scale, scale);
+      ctx.fillStyle = '#FBD5EA';
+      ctx.beginPath();
+      ctx.ellipse(-10, 0, 10, 14, 0, 0, Math.PI * 2);
+      ctx.ellipse(10, 0, 10, 14, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = '#F49BC4';
+      ctx.beginPath();
+      ctx.ellipse(0, 2, 6, 8, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(-6, -12);
+      ctx.quadraticCurveTo(0, -8, 6, -12);
+      ctx.stroke();
+      ctx.restore();
+    }
+  };
+
+  ACCESSORY_RENDERERS.sun_hat = {
+    svg: ({ geo, scale }) => {
+      const y = geo.head.top - 4;
+      const brim = geo.head.rx * 1.25;
+      const crown = geo.head.rx * 0.76;
+      return `<g class="acc acc-sun-hat" transform="translate(0 ${fmt(y)}) scale(${fmt(scale)})">
+          <ellipse cx="0" cy="0" rx="${fmt(brim)}" ry="18" fill="#FBEAC3" stroke="#E6C592" stroke-width="3" />
+          <ellipse cx="0" cy="-10" rx="${fmt(crown)}" ry="22" fill="#FFF4D7" stroke="#E6C592" stroke-width="2.4" />
+          <path d="M-${fmt(crown * 0.7)} -6 Q0 -16 ${fmt(crown * 0.7)} -6" fill="none" stroke="#F7AEC7" stroke-width="5" stroke-linecap="round" />
+        </g>`;
+    },
+    canvas: (ctx, { geo, scale }) => {
+      const y = geo.head.top - 4;
+      const brim = geo.head.rx * 1.25;
+      const crown = geo.head.rx * 0.76;
+      ctx.save();
+      ctx.translate(0, y);
+      ctx.scale(scale, scale);
+      ctx.fillStyle = '#FBEAC3';
+      ctx.strokeStyle = '#E6C592';
+      ctx.lineWidth = 3;
+      ctx.beginPath();
+      ctx.ellipse(0, 0, brim, 18, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+      ctx.fillStyle = '#FFF4D7';
+      ctx.lineWidth = 2.4;
+      ctx.beginPath();
+      ctx.ellipse(0, -10, crown, 22, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+      ctx.strokeStyle = '#F7AEC7';
+      ctx.lineWidth = 5;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(-crown * 0.7, -6);
+      ctx.quadraticCurveTo(0, -16, crown * 0.7, -6);
+      ctx.stroke();
+      ctx.restore();
+    }
+  };
+
+  ACCESSORY_RENDERERS.flower_crown = {
+    svg: ({ geo, scale }) => {
+      const y = geo.crown.y;
+      const floralScale = geo.head.rx / 60;
+      return `<g class="acc acc-flower-crown" transform="translate(0 ${fmt(y)}) scale(${fmt(scale)})">${flowerCrownSVG(floralScale, 0)}</g>`;
+    },
+    canvas: (ctx, { geo, scale }) => {
+      const y = geo.crown.y;
+      const floralScale = geo.head.rx / 60;
+      const petals = [
+        { x: -52, y: -6, r: 12, colour: '#FCDDEB', centre: '#F4A7C4' },
+        { x: -32, y: -12, r: 8, colour: '#CBE7FF', centre: '#7AB2E3' },
+        { x: -8, y: -4, r: 14, colour: '#FFE8D6', centre: '#F4B876' },
+        { x: 14, y: -10, r: 12, colour: '#FFD6E5', centre: '#F58FB8' },
+        { x: 36, y: -8, r: 9, colour: '#C7ECD3', centre: '#76B88B' },
+        { x: 52, y: -6, r: 11, colour: '#F7C6DD', centre: '#E08CB9' }
+      ];
+      const leaves = [
+        { x: -42, y: 2, w: 20, h: 8, colour: '#9FD4A8', rotate: -16 },
+        { x: -4, y: 6, w: 26, h: 9, colour: '#B5E0B7', rotate: 12 },
+        { x: 30, y: 4, w: 22, h: 8, colour: '#8BC598', rotate: 18 }
+      ];
+      ctx.save();
+      ctx.translate(0, y);
+      ctx.scale(scale * floralScale, scale * floralScale);
+      leaves.forEach(leaf => {
+        ctx.save();
+        ctx.translate(leaf.x, leaf.y);
+        ctx.rotate((leaf.rotate * Math.PI) / 180);
+        ctx.fillStyle = leaf.colour;
+        ctx.beginPath();
+        ctx.moveTo(-leaf.w / 2, 0);
+        ctx.quadraticCurveTo(0, -leaf.h, leaf.w / 2, 0);
+        ctx.quadraticCurveTo(0, leaf.h, -leaf.w / 2, 0);
+        ctx.fill();
+        ctx.restore();
+      });
+      petals.forEach(flower => {
+        ctx.save();
+        ctx.translate(flower.x, flower.y);
+        ctx.fillStyle = flower.colour;
+        for (let i = 0; i < 6; i++) {
+          ctx.rotate((Math.PI * 2) / 6);
+          ctx.beginPath();
+          ctx.ellipse(0, flower.r, flower.r * 0.45, flower.r, 0, 0, Math.PI * 2);
+          ctx.fill();
+        }
+        ctx.fillStyle = flower.centre;
+        ctx.beginPath();
+        ctx.arc(0, 0, flower.r * 0.42, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+      });
+      ctx.restore();
+    }
+  };
+
+  ACCESSORY_RENDERERS.bell_charm = {
+    svg: ({ geo, scale }) => {
+      const y = geo.snout.cy + geo.snout.height * 0.92;
+      return `<g class="acc acc-bell" transform="translate(0 ${fmt(y)}) scale(${fmt(scale)})">
+          <path d="M-10 0 Q0 -16 10 0 V8 H-10 Z" fill="#F7E3B2" stroke="#C69C4F" stroke-width="2" />
+          <circle cx="0" cy="5" r="3.6" fill="#C69C4F" />
+          <path d="M-8 -2 Q0 -10 8 -2" stroke="#FFFFFF" stroke-width="1.6" stroke-linecap="round" />
+        </g>`;
+    },
+    canvas: (ctx, { geo, scale }) => {
+      const y = geo.snout.cy + geo.snout.height * 0.92;
+      ctx.save();
+      ctx.translate(0, y);
+      ctx.scale(scale, scale);
+      ctx.beginPath();
+      ctx.moveTo(-10, 0);
+      ctx.quadraticCurveTo(0, -16, 10, 0);
+      ctx.lineTo(10, 8);
+      ctx.lineTo(-10, 8);
+      ctx.closePath();
+      ctx.fillStyle = '#F7E3B2';
+      ctx.strokeStyle = '#C69C4F';
+      ctx.lineWidth = 2;
+      ctx.fill();
+      ctx.stroke();
+      ctx.fillStyle = '#C69C4F';
+      ctx.beginPath();
+      ctx.arc(0, 5, 3.6, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = '#FFFFFF';
+      ctx.lineWidth = 1.6;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(-8, -2);
+      ctx.quadraticCurveTo(0, -10, 8, -2);
+      ctx.stroke();
+      ctx.restore();
+    }
+  };
+
+  ACCESSORY_RENDERERS.fern_garland = {
+    svg: ({ geo, scale }) => {
+      const y = geo.horns.baseLeft.y - 8;
+      const spread = geo.head.rx * 1.3;
+      const leaves = [-spread * 0.6, -spread * 0.2, spread * 0.2, spread * 0.6]
+        .map((x, index) => `<path d="M${fmt(x)} ${fmt(y)} q${fmt(index % 2 === 0 ? -8 : 8)} -6 ${fmt(index % 2 === 0 ? -2 : 2)} -16" stroke="#7DBA8E" stroke-width="3" stroke-linecap="round" />`)
+        .join('');
+      return `<g class="acc acc-fern" transform="scale(${fmt(scale)})">
+          <path d="M-${fmt(spread)} ${fmt(y)} Q0 ${fmt(y - 14)} ${fmt(spread)} ${fmt(y)}" fill="none" stroke="#7DBA8E" stroke-width="5" stroke-linecap="round" />
+          ${leaves}
+        </g>`;
+    },
+    canvas: (ctx, { geo, scale }) => {
+      const y = geo.horns.baseLeft.y - 8;
+      const spread = geo.head.rx * 1.3;
+      ctx.save();
+      ctx.scale(scale, scale);
+      ctx.strokeStyle = '#7DBA8E';
+      ctx.lineWidth = 5;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(-spread, y);
+      ctx.quadraticCurveTo(0, y - 14, spread, y);
+      ctx.stroke();
+      ctx.lineWidth = 3;
+      const offsets = [-spread * 0.6, -spread * 0.2, spread * 0.2, spread * 0.6];
+      offsets.forEach((x, index) => {
+        ctx.beginPath();
+        ctx.moveTo(x, y);
+        const ctrl = index % 2 === 0 ? x - 8 : x + 8;
+        ctx.quadraticCurveTo(ctrl, y - 6, x + (index % 2 === 0 ? -2 : 2), y - 16);
+        ctx.stroke();
+      });
+      ctx.restore();
+    }
+  };
+
+  ACCESSORY_RENDERERS.starry_bandana = {
+    svg: ({ geo, scale }) => {
+      const y = geo.snout.cy + geo.snout.height * 0.4;
+      const width = geo.head.rx * 1.2;
+      return `<g class="acc acc-bandana" transform="translate(0 ${fmt(y)}) scale(${fmt(scale)})">
+          <path d="M-${fmt(width)} -6 L0 18 L${fmt(width)} -6 Z" fill="#364C85" stroke="#223463" stroke-width="3" stroke-linejoin="round" />
+          <circle cx="-${fmt(width * 0.46)}" cy="4" r="3" fill="#F9F1FF" opacity="0.85" />
+          <circle cx="0" cy="10" r="3.8" fill="#F9F1FF" opacity="0.85" />
+          <circle cx="${fmt(width * 0.46)}" cy="4" r="3" fill="#F9F1FF" opacity="0.85" />
+        </g>`;
+    },
+    canvas: (ctx, { geo, scale }) => {
+      const y = geo.snout.cy + geo.snout.height * 0.4;
+      const width = geo.head.rx * 1.2;
+      ctx.save();
+      ctx.translate(0, y);
+      ctx.scale(scale, scale);
+      ctx.beginPath();
+      ctx.moveTo(-width, -6);
+      ctx.lineTo(0, 18);
+      ctx.lineTo(width, -6);
+      ctx.closePath();
+      ctx.fillStyle = '#364C85';
+      ctx.strokeStyle = '#223463';
+      ctx.lineWidth = 3;
+      ctx.fill();
+      ctx.stroke();
+      ctx.fillStyle = 'rgba(249,241,255,0.85)';
+      ctx.beginPath();
+      ctx.arc(-width * 0.46, 4, 3, 0, Math.PI * 2);
+      ctx.arc(0, 10, 3.8, 0, Math.PI * 2);
+      ctx.arc(width * 0.46, 4, 3, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+    }
+  };
+
+  ACCESSORY_RENDERERS.woolly_scarf = {
+    svg: ({ geo, scale }) => {
+      const y = geo.snout.cy + geo.snout.height * 0.58;
+      const width = geo.head.rx * 1.18;
+      return `<g class="acc acc-scarf" transform="translate(0 ${fmt(y)}) scale(${fmt(scale)})">
+          <path d="M-${fmt(width)} -10 Q0 12 ${fmt(width)} -10 L${fmt(width * 0.74)} 12 Q0 26 -${fmt(width * 0.74)} 12 Z" fill="#F2A9B7" stroke="#C97A8A" stroke-width="3" stroke-linejoin="round" />
+          <path d="M-${fmt(width * 0.24)} -4 V18" stroke="#C97A8A" stroke-width="5" stroke-linecap="round" />
+          <path d="M${fmt(width * 0.24)} -4 V18" stroke="#C97A8A" stroke-width="5" stroke-linecap="round" />
+        </g>`;
+    },
+    canvas: (ctx, { geo, scale }) => {
+      const y = geo.snout.cy + geo.snout.height * 0.58;
+      const width = geo.head.rx * 1.18;
+      ctx.save();
+      ctx.translate(0, y);
+      ctx.scale(scale, scale);
+      ctx.beginPath();
+      ctx.moveTo(-width, -10);
+      ctx.quadraticCurveTo(0, 12, width, -10);
+      ctx.lineTo(width * 0.74, 12);
+      ctx.quadraticCurveTo(0, 26, -width * 0.74, 12);
+      ctx.closePath();
+      ctx.fillStyle = '#F2A9B7';
+      ctx.strokeStyle = '#C97A8A';
+      ctx.lineWidth = 3;
+      ctx.fill();
+      ctx.stroke();
+      ctx.lineWidth = 5;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(-width * 0.24, -4);
+      ctx.lineTo(-width * 0.24, 18);
+      ctx.moveTo(width * 0.24, -4);
+      ctx.lineTo(width * 0.24, 18);
+      ctx.stroke();
+      ctx.restore();
+    }
+  };
+}
+
+registerAccessories();
+
+const ACCESSORY_ALIASES: Record<string, string> = {
+  'pastel bow': 'bow_pink',
+  'bow_pink': 'bow_pink',
+  'sun hat': 'sun_hat',
+  'sun_hat': 'sun_hat',
+  'flower crown': 'flower_crown',
+  'thistle crown': 'flower_crown',
+  'bell charm': 'bell_charm',
+  'fern garland': 'fern_garland',
+  'starry bandana': 'starry_bandana',
+  'woolly scarf': 'woolly_scarf'
+};
+
+function resolveAccessoryKey(name: string): string | undefined {
+  return ACCESSORY_ALIASES[normaliseAccessoryName(name)];
+}
+
+function renderAccessorySvg(name: string, cow: Cow, geo: CowGeometry, scale = 1): string {
+  const key = resolveAccessoryKey(name);
+  if (!key) return '';
+  const renderer = ACCESSORY_RENDERERS[key];
+  if (!renderer) return '';
+  return renderer.svg({ cow, geo, scale });
+}
+
+function drawAccessoryCanvas(ctx: CanvasRenderingContext2D, name: string, cow: Cow, geo: CowGeometry, scale = 1): void {
+  const key = resolveAccessoryKey(name);
+  if (!key) return;
+  const renderer = ACCESSORY_RENDERERS[key];
+  renderer?.canvas?.(ctx, { cow, geo, scale });
+}
+
+export function flowerCrownSVG(scale = 1, hueShift = 0): string {
+  const flowers: Array<{ type: 'cosmos' | 'forget' | 'daisy'; x: number; y: number; scale: number; petal: string; centre: string }> = [
+    { type: 'cosmos', x: -52, y: -6, scale: 0.92, petal: '#FCDDEB', centre: '#F4A7C4' },
+    { type: 'forget', x: -30, y: -12, scale: 0.68, petal: '#CBE7FF', centre: '#7AB2E3' },
+    { type: 'daisy', x: -6, y: -4, scale: 1.08, petal: '#FFF4D6', centre: '#F2B976' },
+    { type: 'cosmos', x: 18, y: -10, scale: 0.96, petal: '#FFD6E5', centre: '#F58FB8' },
+    { type: 'forget', x: 38, y: -8, scale: 0.64, petal: '#C6E7F8', centre: '#73B7D9' },
+    { type: 'daisy', x: 56, y: -4, scale: 0.9, petal: '#FFF6E6', centre: '#F3C27D' }
+  ];
+  const leaves: Array<{ x: number; y: number; rotate: number; width: number; height: number; colour: string }> = [
+    { x: -40, y: 4, rotate: -20, width: 22, height: 8, colour: '#9FD4A8' },
+    { x: -8, y: 8, rotate: 12, width: 26, height: 9, colour: '#B5E0B7' },
+    { x: 24, y: 6, rotate: 18, width: 24, height: 8, colour: '#8BC598' },
+    { x: 48, y: 4, rotate: 26, width: 20, height: 7, colour: '#A3D6AF' }
+  ];
+
+  const petals = flowers
+    .map(({ type, x, y, scale: flowerScale, petal, centre }) => {
+      const petalsCount = type === 'daisy' ? 12 : 6;
+      const petalWidth = type === 'forget' ? 10 : 14;
+      const petalHeight = type === 'forget' ? 20 : 26;
+      const petalsMarkup = Array.from({ length: petalsCount })
+        .map((_, index) => {
+          const rotation = (360 / petalsCount) * index;
+          const offset = type === 'daisy' ? 0.9 : 1;
+          return `<ellipse cx="0" cy="${fmt(petalHeight * offset)}" rx="${fmt(petalWidth * 0.35)}" ry="${fmt(petalHeight)}" transform="rotate(${fmt(rotation)})" fill="${shiftHue(petal, hueShift)}" opacity="0.96" />`;
+        })
+        .join('');
+      return `<g class="crown-flower" transform="translate(${fmt(x)} ${fmt(y)}) scale(${fmt(flowerScale * scale)})">${petalsMarkup}<circle cx="0" cy="0" r="${fmt(type === 'daisy' ? 9 : 7)}" fill="${shiftHue(centre, hueShift)}" /></g>`;
     })
+    .join('');
+
+  const leafMarkup = leaves
+    .map(leaf => `<path d="M-${fmt(leaf.width / 2)} 0 Q0 -${fmt(leaf.height)} ${fmt(leaf.width / 2)} 0 Q0 ${fmt(leaf.height)} -${fmt(leaf.width / 2)} 0 Z" transform="translate(${fmt(leaf.x)} ${fmt(leaf.y)}) rotate(${fmt(leaf.rotate)}) scale(${fmt(scale)})" fill="${shiftHue(leaf.colour, hueShift)}" />`)
+    .join('');
+
+  return `<g class="flower-crown" opacity="0.98">${leafMarkup}${petals}</g>`;
+}
+
+function shiftHue(hex: string, degrees: number): string {
+  if (!degrees) return hex;
+  const { h, s, l } = hexToHsl(hex);
+  return hslToHex({ h: (h + degrees + 360) % 360, s, l });
+}
+
+function hexToHsl(hex: string): { h: number; s: number; l: number } {
+  const value = hex.replace('#', '');
+  const bigint = parseInt(value, 16);
+  const r = ((bigint >> 16) & 255) / 255;
+  const g = ((bigint >> 8) & 255) / 255;
+  const b = (bigint & 255) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+  const d = max - min;
+  if (d !== 0) {
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+  return { h: h * 360, s: s * 100, l: l * 100 };
+}
+
+function hslToHex({ h, s, l }: { h: number; s: number; l: number }): string {
+  const hue = h / 360;
+  const sat = s / 100;
+  const light = l / 100;
+  const hueToRgb = (p: number, q: number, t: number): number => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  let r: number;
+  let g: number;
+  let b: number;
+  if (sat === 0) {
+    r = g = b = light;
+  } else {
+    const q = light < 0.5 ? light * (1 + sat) : light + sat - light * sat;
+    const p = 2 * light - q;
+    r = hueToRgb(p, q, hue + 1 / 3);
+    g = hueToRgb(p, q, hue);
+    b = hueToRgb(p, q, hue - 1 / 3);
+  }
+  const toHex = (x: number) => Math.round(x * 255).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function buildEyeState(pose: CowPose, mood: MoodState): 'open' | 'half' | 'closed' {
+  if (pose === 'blink') return 'closed';
+  if (mood === 'sleepy') return 'half';
+  return 'open';
+}
+
+type MoodState = 'happy' | 'calm' | 'sleepy' | 'worried';
+
+export function moodFromStats(happiness: number, hunger: number, cleanliness: number): MoodState {
+  if (happiness >= 72 && hunger <= 45 && cleanliness >= 60) return 'happy';
+  if (hunger >= 75 || cleanliness <= 34) return 'worried';
+  if (happiness <= 45 || hunger >= 60) return 'sleepy';
+  return 'calm';
+}
+
+export function renderAccessory(name: string, cow: Cow, scale = 1): string {
+  const geo = computeGeometry(cow, 'idle');
+  return renderAccessorySvg(name, cow, geo, scale);
+}
+
+function renderAccessoriesLayer(cow: Cow, geo: CowGeometry): string {
+  if (!cow.accessories?.length) return '';
+  return cow.accessories
+    .map(name => renderAccessorySvg(name, cow, geo))
+    .filter(Boolean)
     .join('');
 }
 
-function drawAccessories(
-  ctx: CanvasRenderingContext2D,
-  cow: Cow,
-  meta: CowVisualOptions & AccessoryRenderMeta,
-): void {
-  (cow.accessories || []).forEach(name => {
-    const entry = AccessoryLibrary[name];
-    if (entry && typeof entry.draw === 'function') {
-      entry.draw(ctx, cow, meta);
-    } else if (entry && entry.icon) {
-      ctx.save();
-      const fallbackY = meta.anatomy.head.centerY - meta.anatomy.head.height * 0.4;
-      ctx.translate(0, fallbackY);
-      ctx.font = '18px sans-serif';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillText(entry.icon, 0, 0);
-      ctx.restore();
-    }
+function drawAccessoriesLayer(ctx: CanvasRenderingContext2D, cow: Cow, geo: CowGeometry): void {
+  cow.accessories?.forEach(name => {
+    drawAccessoryCanvas(ctx, name, cow, geo);
   });
 }
 
-function computeScale(cow: Cow, options: CowVisualOptions = {}): CowScaleMeta {
-  const chonkBoost = Math.max(0, (cow.chonk || 0) - 60);
-  const baseScale = options.scale || 1;
-  const scale = baseScale * (1 + Math.min(0.22, chonkBoost / 160));
-  const bellyOffset = Math.min(10, chonkBoost * 0.2);
-  const bellyStretch = Math.min(9, chonkBoost * 0.18);
-
-  const bodyCenterY = 28 + bellyOffset;
-  const bodyRx = 40 + bellyStretch;
-  const bodyRy = 28 + bellyStretch * 0.9;
-  const bodyHighlightRx = 24 + bellyStretch * 0.5;
-  const bodyHighlightRy = 12 + bellyStretch * 0.4;
-
-  const headWidth = 58 + Math.min(6, chonkBoost * 0.08);
-  const headHeight = 44 + Math.min(5, chonkBoost * 0.05);
-  const headCenterY = -4 + Math.min(2.4, chonkBoost * 0.04);
-  const headTop = headCenterY - headHeight / 2;
-
-  const hornsThickness = 8 + Math.min(2.5, chonkBoost * 0.04);
-  const hornsBaseY = headTop - 4;
-  const hornsTipY = hornsBaseY - (16 + Math.min(5, chonkBoost * 0.05));
-  const hornsInnerSpread = headWidth * 0.34;
-  const hornsOuterSpread = headWidth * 0.74;
-
-  const earsHeight = headHeight * 0.58;
-
-  const anatomy: CowAnatomy = {
-    body: {
-      centerY: bodyCenterY,
-      rx: bodyRx,
-      ry: bodyRy,
-      highlightRx: bodyHighlightRx,
-      highlightRy: bodyHighlightRy,
-    },
-    head: {
-      width: headWidth,
-      height: headHeight,
-      centerY: headCenterY,
-    },
-    horns: {
-      baseY: hornsBaseY,
-      tipY: hornsTipY,
-      innerSpread: hornsInnerSpread,
-      outerSpread: hornsOuterSpread,
-      thickness: hornsThickness,
-    },
-    ears: {
-      baseY: headCenterY - headHeight * 0.08,
-      width: headWidth * 0.32,
-      height: earsHeight,
-      tilt: 0.28 + Math.min(0.12, chonkBoost / 520),
-    },
-    muzzle: {
-      y: headCenterY + headHeight * 0.42,
-      width: headWidth * 0.52,
-      height: headHeight * 0.42 + Math.min(2.4, chonkBoost * 0.03),
-      nostrilOffset: headWidth * 0.18,
-    },
-    hooves: {
-      y: bodyCenterY + bodyRy - 4,
-      width: 12 + Math.min(3, chonkBoost * 0.04),
-      height: 8 + Math.min(3, chonkBoost * 0.03),
-      spacing: 26 + Math.min(6, chonkBoost * 0.07),
-    },
-    eyes: {
-      y: headCenterY + headHeight * 0.04,
-      spacing: headWidth * 0.32,
-      radius: 4.4 + Math.min(0.8, chonkBoost * 0.01),
-    },
-    cheeks: {
-      y: headCenterY + headHeight * 0.32,
-      spacing: headWidth * 0.36,
-      radius: headHeight * 0.22,
-    },
-    fringe: {
-      layers: [
-        { width: headWidth * 0.98, height: headHeight * 0.7, offsetY: -headHeight * 0.1 },
-        { width: headWidth * 0.86, height: headHeight * 0.54, offsetY: headHeight * 0.02 },
-        { width: headWidth * 0.7, height: headHeight * 0.36, offsetY: headHeight * 0.18 },
-      ],
-      swoopDepth: headHeight * 0.62,
-      bangDepth: headHeight * 0.32,
-    },
-  };
-
-  return { scale, bellyOffset, bellyStretch, chonkBoost, anatomy };
-}
-
-function baseTraits(cow: Cow): CowTraits {
-  return {
-    sleepyEyes: cow.personality === 'Sleepy',
-    rosyCheeks: cow.personality === 'Social' || cow.personality === 'Vain',
-    fancyLashes: cow.personality === 'Vain',
-    raisedBrow: cow.personality === 'Greedy',
-  };
-}
-
-function resolveTraits(cow: Cow, options: CowVisualOptions): CowTraits {
-  const traits = baseTraits(cow);
-  if (options.traits) {
-    (Object.entries(options.traits) as Array<[keyof CowTraits, boolean | undefined]>).forEach(([key, value]) => {
-      if (typeof value === 'boolean') {
-        traits[key] = value;
-      }
-    });
+export function svg(cow: Cow, opts: CowSvgOptions = {}): string {
+  const pose: CowPose = opts.pose || 'idle';
+  const size = opts.size ?? DEFAULT_SIZE;
+  const highContrast = !!opts.highContrast;
+  const geometry = computeGeometry(cow, pose);
+  const coat = COAT_COLOURS[cow.colour] || COAT_COLOURS.brown;
+  const defs = createDefs(geometry, coat, highContrast);
+  const mood = moodFromStats(cow.happiness ?? 50, cow.hunger ?? 50, cow.cleanliness ?? 50);
+  const chonkClass = `chonk-${chonkBucket(cow.chonk)}`;
+  const classes = ['cow-svg', 'cow-figure', `pose-${pose}`, `mood-${mood}`, `coat-${cow.colour}`, chonkClass];
+  if (opts.className) classes.push(opts.className);
+  if (highContrast) classes.push('high-contrast');
+  const viewBoxDef = parseViewBox(opts.viewBox) ?? DEFAULT_VIEWBOX;
+  const scale = opts.scale ?? 1;
+  const offsetX = opts.offsetX ?? 0;
+  const offsetY = opts.offsetY ?? 0;
+  const rootOffsetX = viewBoxDef.x + viewBoxDef.width / 2 + offsetX;
+  const rootOffsetY = viewBoxDef.y + viewBoxDef.height / 2 + offsetY;
+  const transformParts: string[] = [];
+  if (rootOffsetX || rootOffsetY) {
+    transformParts.push(`translate(${fmt(rootOffsetX)} ${fmt(rootOffsetY)})`);
   }
-  return traits;
+  if (scale !== 1) {
+    transformParts.push(`scale(${fmt(scale)})`);
+  }
+  const rootTransformAttr = transformParts.length ? ` transform="${transformParts.join(' ')}"` : '';
+  const viewBoxAttr = `${fmt(viewBoxDef.x)} ${fmt(viewBoxDef.y)} ${fmt(viewBoxDef.width)} ${fmt(viewBoxDef.height)}`;
+  const fringe = buildFringePaths(geometry);
+  const styleVars = `--coat-base:${coat.base};--coat-shade:${coat.shade};--coat-light:${coat.light};--chonk:${geometry.chonk.toFixed(3)};--bob-strength:${geometry.bobStrength.toFixed(3)};`;
+  const eyeState = buildEyeState(pose, mood);
+  const eyelidColour = shiftHue(coat.base, -4);
+  const blushOpacity = lerp(BLUSH_MIN_OPACITY, BLUSH_MAX_OPACITY, 0.6 + geometry.chonk * 0.4);
+  const glow = buildPastureGlow(geometry, defs.glowGradient);
+  const accessories = renderAccessoriesLayer(cow, geometry);
+
+  const svgStyle = `<style>
+      .cow-figure { overflow: visible; }
+      .cow-figure .cow-root-group { transform-box: fill-box; transform-origin: 50% 70%; }
+      .cow-figure .cow-body-group { transform-origin: 0 ${fmt(geometry.body.cy)}; }
+      .cow-figure.pose-walk .cow-body-group { animation: cow-bob 2.8s ease-in-out infinite; }
+      .cow-figure.pose-idle .cow-body-group { animation: cow-sway 5.4s ease-in-out infinite; }
+      .cow-figure .cow-leg.front { transform-origin: center ${fmt(geometry.body.cy + geometry.body.ry)}; }
+      .cow-figure.pose-walk .cow-leg.front-left { animation: leg-swing 1.4s ease-in-out infinite; }
+      .cow-figure.pose-walk .cow-leg.front-right { animation: leg-swing 1.4s ease-in-out infinite reverse; }
+      .cow-figure.pose-walk .cow-leg.back-left { animation: leg-swing 1.4s ease-in-out infinite reverse; }
+      .cow-figure.pose-walk .cow-leg.back-right { animation: leg-swing 1.4s ease-in-out infinite; }
+      .cow-figure .cow-fringe, .cow-figure .cow-fringe-back { transform-origin: 0 ${fmt(geometry.fringe.top + 4)}; }
+      .cow-figure.pose-walk .cow-fringe, .cow-figure.pose-walk .cow-fringe-back { animation: fringe-bob 2.8s ease-in-out infinite; }
+      .cow-figure .eye-half, .cow-figure .eye-closed, .cow-figure .eye-lid { opacity: 0; }
+      .cow-figure.mood-sleepy .eye-half { opacity: 1; }
+      .cow-figure.pose-blink .eye-open, .cow-figure.auto-blink .eye-open { opacity: 0; }
+      .cow-figure.pose-blink .eye-closed, .cow-figure.auto-blink .eye-closed { opacity: 1; }
+      .cow-figure.pose-blink .eye-lid, .cow-figure.auto-blink .eye-lid { opacity: 1; }
+      .cow-figure .eyebrow { transition: transform 0.4s ease; transform-origin: center; }
+      .cow-figure.mood-worried .eyebrow-left { transform: rotate(-10deg) translateY(-1px); }
+      .cow-figure.mood-worried .eyebrow-right { transform: rotate(10deg) translateY(-1px); }
+      @keyframes cow-bob { 0% { transform: translateY(0); } 50% { transform: translateY(${fmt(-4.8 * geometry.bobStrength)}); } 100% { transform: translateY(0); } }
+      @keyframes cow-sway { 0% { transform: translateY(0); } 50% { transform: translateY(${fmt(-1.8 * geometry.bobStrength)}); } 100% { transform: translateY(0); } }
+      @keyframes fringe-bob { 0% { transform: rotate(0); } 50% { transform: rotate(${fmt(2.6 * geometry.bobStrength)}deg); } 100% { transform: rotate(0); } }
+      @keyframes leg-swing { 0% { transform: rotate(${fmt(3 * geometry.bobStrength)}deg); } 50% { transform: rotate(${fmt(-3 * geometry.bobStrength)}deg); } 100% { transform: rotate(${fmt(3 * geometry.bobStrength)}deg); } }
+    </style>`;
+
+  return `<svg class="${classes.join(' ')}" data-name="${cow.name}" role="img" aria-label="${cow.name} Highland calf" viewBox="${viewBoxAttr}" width="${fmt(size)}" height="${fmt(size)}" style="${styleVars}">
+      ${svgStyle}
+      <defs>${defs.defs}</defs>
+      <g class="cow-root-group"${rootTransformAttr}>
+        ${glow}
+        <g class="cow-body-group">
+        <ellipse class="cow-body" cx="${fmt(geometry.body.cx)}" cy="${fmt(geometry.body.cy)}" rx="${fmt(geometry.body.rx)}" ry="${fmt(geometry.body.ry)}" fill="url(#${defs.bodyGradient})" stroke="${highContrast ? '#4A2C3A' : 'none'}" stroke-width="${highContrast ? '2.4' : '0'}" />
+        <ellipse class="cow-belly" cx="${fmt(geometry.body.cx)}" cy="${fmt(geometry.body.bellyCy)}" rx="${fmt(geometry.body.bellyRx)}" ry="${fmt(geometry.body.bellyRy)}" fill="rgba(255,255,255,0.24)" />
+        <ellipse class="cow-shadow" cx="${fmt(geometry.body.cx)}" cy="${fmt(geometry.body.cy + geometry.body.ry * 0.55)}" rx="${fmt(geometry.body.rx * 0.64)}" ry="${fmt(geometry.body.ry * 0.45)}" fill="rgba(74,44,58,0.08)" />
+        </g>
+        <g class="cow-legs">
+        ${geometry.legs.map(leg => `<path class="cow-leg ${leg.position}-${leg.side}" d="${buildLegPath(leg)}" fill="${coat.shade}" />`).join('')}
+        ${geometry.legs.map(leg => `<path class="cow-hoof" d="${buildHoofPath(leg)}" fill="#534448" />`).join('')}
+        </g>
+        <g class="cow-head">
+        <path class="cow-horn left" d="${buildHornPath(geometry, 'left')}" fill="url(#${defs.hornGradient})" stroke="${highContrast ? '#806F57' : 'none'}" stroke-width="${highContrast ? '1.6' : '0'}" />
+        <path class="cow-horn right" d="${buildHornPath(geometry, 'right')}" fill="url(#${defs.hornGradient})" stroke="${highContrast ? '#806F57' : 'none'}" stroke-width="${highContrast ? '1.6' : '0'}" />
+        <path class="cow-ear left" d="${buildEarPath(geometry.ears.left, 'left')}" fill="${shiftHue(coat.base, -6)}" />
+        <path class="cow-ear right" d="${buildEarPath(geometry.ears.right, 'right')}" fill="${shiftHue(coat.base, -6)}" />
+        <path class="cow-ear-inner left" d="${buildEarInnerPath(geometry.ears.left, 'left')}" fill="rgba(255,221,235,0.85)" />
+        <path class="cow-ear-inner right" d="${buildEarInnerPath(geometry.ears.right, 'right')}" fill="rgba(255,221,235,0.85)" />
+        <ellipse class="cow-head" cx="${fmt(geometry.head.cx)}" cy="${fmt(geometry.head.cy)}" rx="${fmt(geometry.head.rx)}" ry="${fmt(geometry.head.ry)}" fill="url(#${defs.headGradient})" stroke="${highContrast ? '#4A2C3A' : 'none'}" stroke-width="${highContrast ? '2.2' : '0'}" />
+        <path class="cow-fringe-back" d="${fringe.back}" fill="${shiftHue(coat.base, -10)}" />
+        <g class="cow-eyes" fill="${EYE_COLOUR}">
+          <ellipse class="eye-open" cx="${fmt(geometry.eyes.left.cx)}" cy="${fmt(geometry.eyes.left.cy)}" rx="${fmt(geometry.eyes.left.rx)}" ry="${fmt(geometry.eyes.left.ry)}" opacity="${eyeState === 'open' ? '1' : '0'}" />
+          <ellipse class="eye-open" cx="${fmt(geometry.eyes.right.cx)}" cy="${fmt(geometry.eyes.right.cy)}" rx="${fmt(geometry.eyes.right.rx)}" ry="${fmt(geometry.eyes.right.ry)}" opacity="${eyeState === 'open' ? '1' : '0'}" />
+          <path class="eye-half" d="${buildEyeHalfPath(geometry.eyes.left.cx, geometry.eyes.left.cy, geometry.eyes.left.rx, geometry.eyes.left.ry)}" fill="${eyelidColour}" opacity="${eyeState === 'half' ? '1' : '0'}" />
+          <path class="eye-half" d="${buildEyeHalfPath(geometry.eyes.right.cx, geometry.eyes.right.cy, geometry.eyes.right.rx, geometry.eyes.right.ry)}" fill="${eyelidColour}" opacity="${eyeState === 'half' ? '1' : '0'}" />
+          <path class="eye-closed" d="${buildEyeClosedPath(geometry.eyes.left.cx, geometry.eyes.left.cy, geometry.eyes.left.rx)}" stroke="${eyelidColour}" stroke-width="3" stroke-linecap="round" />
+          <path class="eye-closed" d="${buildEyeClosedPath(geometry.eyes.right.cx, geometry.eyes.right.cy, geometry.eyes.right.rx)}" stroke="${eyelidColour}" stroke-width="3" stroke-linecap="round" />
+          <path class="eye-lid" d="${buildEyeHalfPath(geometry.eyes.left.cx, geometry.eyes.left.cy, geometry.eyes.left.rx, geometry.eyes.left.ry)}" fill="${eyelidColour}" opacity="0" />
+          <path class="eye-lid" d="${buildEyeHalfPath(geometry.eyes.right.cx, geometry.eyes.right.cy, geometry.eyes.right.rx, geometry.eyes.right.ry)}" fill="${eyelidColour}" opacity="0" />
+          <path class="eye-highlight" d="${buildEyeHighlight(geometry.eyes.left.cx, geometry.eyes.left.cy)}" fill="rgba(255,255,255,0.7)" />
+          <path class="eye-highlight" d="${buildEyeHighlight(geometry.eyes.right.cx, geometry.eyes.right.cy)}" fill="rgba(255,255,255,0.7)" />
+          <path class="eyebrow eyebrow-left" d="${buildBrowPath(geometry.eyes.left.cx, geometry.eyes.left.cy - geometry.eyes.left.ry - 6, geometry.eyes.left.rx * 0.95, 3)}" stroke="${shiftHue(coat.shade, -10)}" stroke-width="3" stroke-linecap="round" fill="none" />
+          <path class="eyebrow eyebrow-right" d="${buildBrowPath(geometry.eyes.right.cx, geometry.eyes.right.cy - geometry.eyes.right.ry - 6, geometry.eyes.right.rx * 0.95, -3)}" stroke="${shiftHue(coat.shade, -10)}" stroke-width="3" stroke-linecap="round" fill="none" />
+        </g>
+        <path class="cow-fringe" d="${fringe.front}" fill="${shiftHue(coat.light, -8)}" />
+        <path class="cow-snout" d="${buildSnoutPath(geometry)}" fill="url(#${defs.snoutGradient})" />
+        <path class="cow-snout-highlight" d="${buildSnoutHighlightPath(geometry)}" fill="rgba(255,255,255,0.35)" />
+        <ellipse class="nostril" cx="${fmt(-geometry.snout.nostrilGap / 2)}" cy="${fmt(geometry.snout.cy + 6)}" rx="${fmt(geometry.snout.nostrilRadius)}" ry="${fmt(geometry.snout.nostrilRadius * 0.65)}" fill="${shiftHue(coat.shade, -16)}" />
+        <ellipse class="nostril" cx="${fmt(geometry.snout.nostrilGap / 2)}" cy="${fmt(geometry.snout.cy + 6)}" rx="${fmt(geometry.snout.nostrilRadius)}" ry="${fmt(geometry.snout.nostrilRadius * 0.65)}" fill="${shiftHue(coat.shade, -16)}" />
+        <ellipse class="cow-blush" cx="${fmt(geometry.blush.left.cx)}" cy="${fmt(geometry.blush.left.cy)}" rx="${fmt(geometry.blush.left.rx)}" ry="${fmt(geometry.blush.left.ry)}" fill="${BLUSH_COLOUR}" opacity="${fmt(blushOpacity)}" />
+        <ellipse class="cow-blush" cx="${fmt(geometry.blush.right.cx)}" cy="${fmt(geometry.blush.right.cy)}" rx="${fmt(geometry.blush.right.rx)}" ry="${fmt(geometry.blush.right.ry)}" fill="${BLUSH_COLOUR}" opacity="${fmt(blushOpacity)}" />
+        </g>
+        ${accessories}
+      </g>
+    </svg>`;
 }
 
-function hornPath(anatomy: CowAnatomy, side: 'left' | 'right'): string {
-  const { horns } = anatomy;
-  const dir = side === 'left' ? -1 : 1;
-  const baseX = dir * horns.innerSpread;
-  const baseY = horns.baseY;
-  const tipX = dir * horns.outerSpread;
-  const tipY = horns.tipY;
-  const thickness = horns.thickness;
-  const upperCtrlX = dir * (horns.innerSpread + 6);
-  const upperCtrlY = baseY - thickness * 1.1;
-  const upperCtrl2X = dir * (horns.outerSpread - 8);
-  const upperCtrl2Y = tipY - thickness * 0.6;
-  const lowerCtrl1X = dir * (horns.outerSpread + 6);
-  const lowerCtrl1Y = tipY + thickness * 1.2;
-  const lowerCtrl2X = dir * (horns.innerSpread + 10);
-  const lowerCtrl2Y = baseY + thickness * 0.8;
-  const bottomY = baseY + thickness + 2;
-  return `M${fmt(baseX)},${fmt(baseY)} C${fmt(upperCtrlX)},${fmt(upperCtrlY)} ${fmt(upperCtrl2X)},${fmt(upperCtrl2Y)} ${fmt(tipX)},${fmt(tipY)} C${fmt(lowerCtrl1X)},${fmt(lowerCtrl1Y)} ${fmt(lowerCtrl2X)},${fmt(lowerCtrl2Y)} ${fmt(baseX)},${fmt(bottomY)} Z`;
-}
-
-function hornHighlightPath(anatomy: CowAnatomy, side: 'left' | 'right'): string {
-  const { horns } = anatomy;
-  const dir = side === 'left' ? -1 : 1;
-  const startX = dir * (horns.innerSpread + 3);
-  const startY = horns.baseY + horns.thickness * 0.2;
-  const controlX = dir * (horns.innerSpread + horns.outerSpread) * 0.5;
-  const controlY = horns.tipY + horns.thickness * 0.3;
-  const endX = dir * (horns.outerSpread - 2);
-  const endY = horns.tipY + horns.thickness * 0.6;
-  return `M${fmt(startX)},${fmt(startY)} Q${fmt(controlX)},${fmt(controlY)} ${fmt(endX)},${fmt(endY)}`;
-}
-
-function earPath(anatomy: CowAnatomy, side: 'left' | 'right'): string {
-  const { ears, head } = anatomy;
-  const dir = side === 'left' ? -1 : 1;
-  const baseX = dir * (head.width * 0.46);
-  const baseY = ears.baseY;
-  const tipX = dir * (head.width * (0.76 + ears.tilt * 0.2));
-  const tipY = baseY - ears.height;
-  const frontCtrlX = dir * (head.width * (0.64 + ears.tilt * 0.4));
-  const frontCtrlY = baseY - ears.height * 0.6;
-  const rearCtrlX = dir * (head.width * 0.68);
-  const rearCtrlY = baseY + ears.height * 0.18;
-  const lowerX = dir * (head.width * 0.44);
-  const lowerY = baseY + ears.height * 0.52;
-  const innerX = dir * (head.width * 0.38);
-  const innerY = baseY + ears.height * 0.22;
-  return `M${fmt(baseX)},${fmt(baseY)} Q${fmt(frontCtrlX)},${fmt(frontCtrlY)} ${fmt(tipX)},${fmt(tipY)} Q${fmt(rearCtrlX)},${fmt(rearCtrlY)} ${fmt(lowerX)},${fmt(lowerY)} Q${fmt(innerX)},${fmt(innerY)} ${fmt(baseX)},${fmt(baseY)} Z`;
-}
-
-function earInnerPath(anatomy: CowAnatomy, side: 'left' | 'right'): string {
-  const { ears, head } = anatomy;
-  const dir = side === 'left' ? -1 : 1;
-  const baseX = dir * (head.width * 0.44);
-  const baseY = ears.baseY + ears.height * 0.12;
-  const tipX = dir * (head.width * (0.64 + ears.tilt * 0.12));
-  const tipY = baseY - ears.height * 0.72;
-  const innerCtrlX = dir * (head.width * 0.52);
-  const innerCtrlY = baseY + ears.height * 0.24;
-  return `M${fmt(baseX)},${fmt(baseY)} Q${fmt(innerCtrlX)},${fmt(innerCtrlY)} ${fmt(tipX)},${fmt(tipY)} Q${fmt(dir * (head.width * 0.54))},${fmt(baseY + ears.height * 0.18)} ${fmt(baseX)},${fmt(baseY)} Z`;
-}
-
-function fringeLayerPath(anatomy: CowAnatomy, index: number): string {
-  const layer = anatomy.fringe.layers[index];
-  const centerY = anatomy.head.centerY + layer.offsetY;
-  const width = layer.width;
-  const height = layer.height;
-  const left = -width / 2;
-  const right = width / 2;
-  const bottomY = centerY + height / 2;
-  const topY = centerY - anatomy.fringe.swoopDepth * (0.58 - index * 0.08);
-  return `M${fmt(left)},${fmt(bottomY)} C${fmt(left + width * 0.18)},${fmt(topY)} ${fmt(right - width * 0.18)},${fmt(topY)} ${fmt(right)},${fmt(bottomY)} Q0,${fmt(bottomY + height * 0.22)} ${fmt(left)},${fmt(bottomY)} Z`;
-}
-
-function fringeBangPath(anatomy: CowAnatomy): string {
-  const width = anatomy.head.width * 0.94;
-  const left = -width / 2;
-  const right = width / 2;
-  const bottomY = anatomy.head.centerY + anatomy.head.height * 0.18;
-  const topY = anatomy.head.centerY - anatomy.fringe.bangDepth;
-  return `M${fmt(left)},${fmt(bottomY)} Q${fmt(left * 0.4)},${fmt(topY)} 0,${fmt(topY + 6)} Q${fmt(right * 0.4)},${fmt(topY)} ${fmt(right)},${fmt(bottomY)} Z`;
-}
-
-function mouthPath(anatomy: CowAnatomy): string {
-  const width = anatomy.muzzle.width * 0.5;
-  const left = -width / 2;
-  const right = width / 2;
-  const mouthY = anatomy.muzzle.y + anatomy.muzzle.height * 0.18;
-  return `M${fmt(left)},${fmt(mouthY)} Q0,${fmt(mouthY + anatomy.muzzle.height * 0.16)} ${fmt(right)},${fmt(mouthY)}`;
-}
-
-function browPath(anatomy: CowAnatomy, side: 'left' | 'right'): string {
-  const dir = side === 'left' ? -1 : 1;
-  const outerX = dir * (anatomy.eyes.spacing * 0.7);
-  const innerX = dir * (anatomy.eyes.spacing * 0.24);
-  const browY = anatomy.eyes.y - anatomy.eyes.radius * 1.8;
-  return `M${fmt(outerX)},${fmt(browY)} Q${fmt(dir * (anatomy.eyes.spacing * 0.35))},${fmt(browY - 2)} ${fmt(innerX)},${fmt(browY - 0.4)}`;
-}
-
-function eyePositions(anatomy: CowAnatomy): { left: number; right: number } {
-  const half = anatomy.eyes.spacing / 2;
-  return { left: -half, right: half };
-}
-
-export function drawCanvas(
-  ctx: CanvasRenderingContext2D,
-  cow: Cow,
-  options: CowVisualOptions = {}
-): void {
-  const { scale, anatomy } = computeScale(cow, options);
-  const body = colourHex(cow.colour);
-  const fringeColour = colourHex(cow.colour === 'white' ? 'cream' : cow.colour);
-  const muzzleColour = lighten(body, 0.28);
-  const hornColour = lighten(body, 0.4);
-  const hoofColour = darken(body, 0.35);
-  const earOuter = darken(fringeColour, 0.08);
-  const earInner = lighten(fringeColour, 0.2);
-  const fringeShadow = darken(fringeColour, 0.18);
-  const fringeHighlight = lighten(fringeColour, 0.16);
-  const outlineColour = darken(body, 0.2);
-  const cheekColour = mixColour(fringeColour, '#f597b3', 0.55);
-  const traits = resolveTraits(cow, options);
-  const idleWobble = options.animations?.idleWobble !== false;
-  const wobble = idleWobble ? options.wobble || 0 : 0;
-  const bodyRy = anatomy.body.ry + wobble * 0.15;
-  const clipTop = Math.min(anatomy.horns.tipY - 12, anatomy.head.centerY - anatomy.head.height * 0.5);
-  const clipBottom = anatomy.head.centerY - anatomy.head.height * 0.05;
-  const clipHeight = Math.max(0, clipBottom - clipTop);
+export function drawCanvas(ctx: CanvasRenderingContext2D, cow: Cow, opts: CowCanvasOptions = {}): void {
+  const width = opts.w ?? ctx.canvas.width;
+  const height = opts.h ?? ctx.canvas.height;
+  const pose: CowPose = opts.pose || 'idle';
   ctx.save();
-  if (options.x || options.y) {
-    ctx.translate(options.x || 0, options.y || 0);
-  }
-  if (options.rotation) {
-    ctx.rotate(options.rotation);
-  }
+  ctx.clearRect(0, 0, width, height);
+  const scale = Math.min(width / 240, height / 240);
+  ctx.translate(width / 2, height / 2 + 10);
   ctx.scale(scale, scale);
-  ctx.translate(0, options.offsetY || 0);
-  // Body
-  ctx.fillStyle = body;
+
+  const geometry = computeGeometry(cow, pose, now());
+  const coat = COAT_COLOURS[cow.colour] || COAT_COLOURS.brown;
+  const fringe = buildFringePaths(geometry);
+  const eyeState = buildEyeState(pose, moodFromStats(cow.happiness ?? 50, cow.hunger ?? 50, cow.cleanliness ?? 50));
+
+  const glow = ctx.createRadialGradient(0, geometry.body.cy + geometry.body.ry * 0.55, 20, 0, geometry.body.cy + geometry.body.ry * 0.55, geometry.body.rx * 1.6);
+  glow.addColorStop(0, 'rgba(255,246,252,0.78)');
+  glow.addColorStop(1, 'rgba(255,246,252,0)');
+  ctx.fillStyle = glow;
   ctx.beginPath();
-  ctx.ellipse(0, anatomy.body.centerY, anatomy.body.rx, bodyRy, 0, 0, Math.PI * 2);
+  ctx.ellipse(0, geometry.body.cy + geometry.body.ry * 0.55, geometry.body.rx * 1.6, geometry.body.ry * 1.2, 0, 0, Math.PI * 2);
   ctx.fill();
 
-  ctx.fillStyle = 'rgba(0,0,0,0.08)';
+  const bodyGrad = ctx.createLinearGradient(0, geometry.body.cy - geometry.body.ry, 0, geometry.body.cy + geometry.body.ry);
+  bodyGrad.addColorStop(0, coat.light);
+  bodyGrad.addColorStop(0.65, coat.base);
+  bodyGrad.addColorStop(1, coat.shade);
+  ctx.fillStyle = bodyGrad;
   ctx.beginPath();
-  ctx.ellipse(
-    0,
-    anatomy.body.centerY + anatomy.body.ry * 0.4,
-    anatomy.body.rx * 0.7,
-    bodyRy * 0.5,
-    0,
-    0,
-    Math.PI * 2,
-  );
+  ctx.ellipse(geometry.body.cx, geometry.body.cy, geometry.body.rx, geometry.body.ry, 0, 0, Math.PI * 2);
   ctx.fill();
 
-  ctx.fillStyle = 'rgba(255,255,255,0.16)';
+  ctx.fillStyle = 'rgba(255,255,255,0.24)';
   ctx.beginPath();
-  ctx.ellipse(
-    0,
-    anatomy.body.centerY - anatomy.body.ry * 0.2,
-    anatomy.body.highlightRx,
-    anatomy.body.highlightRy,
-    0,
-    0,
-    Math.PI * 2,
-  );
+  ctx.ellipse(geometry.body.cx, geometry.body.bellyCy, geometry.body.bellyRx, geometry.body.bellyRy, 0, 0, Math.PI * 2);
   ctx.fill();
 
-  // Hooves
-  ctx.fillStyle = hoofColour;
-  [-1, 1].forEach(direction => {
-    const x = direction * anatomy.hooves.spacing * 0.5;
-    ctx.beginPath();
-    ctx.ellipse(x, anatomy.hooves.y, anatomy.hooves.width, anatomy.hooves.height, 0, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.strokeStyle = 'rgba(255,255,255,0.25)';
-    ctx.lineWidth = 1.1;
-    ctx.beginPath();
-    ctx.ellipse(
-      x,
-      anatomy.hooves.y - anatomy.hooves.height * 0.25,
-      anatomy.hooves.width * 0.7,
-      anatomy.hooves.height * 0.45,
-      0,
-      0,
-      Math.PI * 2,
-    );
-    ctx.stroke();
+  ctx.fillStyle = 'rgba(74,44,58,0.08)';
+  ctx.beginPath();
+  ctx.ellipse(geometry.body.cx, geometry.body.cy + geometry.body.ry * 0.55, geometry.body.rx * 0.64, geometry.body.ry * 0.45, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  geometry.legs.forEach(leg => {
+    const legPath = new Path2D(buildLegPath(leg));
+    ctx.fillStyle = coat.shade;
+    ctx.fill(legPath);
+    const hoofPath = new Path2D(buildHoofPath(leg));
+    ctx.fillStyle = '#534448';
+    ctx.fill(hoofPath);
   });
 
-  // Horns
-  ['left', 'right'].forEach(side => {
-    const path = new Path2D(hornPath(anatomy, side as 'left' | 'right'));
-    ctx.fillStyle = hornColour;
-    ctx.fill(path);
-    ctx.strokeStyle = darken(hornColour, 0.2);
-    ctx.lineWidth = 1.6;
-    ctx.stroke(path);
-    ctx.strokeStyle = 'rgba(255,255,255,0.45)';
-    ctx.lineWidth = 1.4;
-    ctx.lineCap = 'round';
-    ctx.stroke(new Path2D(hornHighlightPath(anatomy, side as 'left' | 'right')));
-  });
-
-  // Ears
-  ['left', 'right'].forEach(side => {
-    const outer = new Path2D(earPath(anatomy, side as 'left' | 'right'));
-    ctx.fillStyle = earOuter;
-    ctx.fill(outer);
-    ctx.strokeStyle = darken(earOuter, 0.12);
-    ctx.lineWidth = 1.2;
-    ctx.stroke(outer);
-    const inner = new Path2D(earInnerPath(anatomy, side as 'left' | 'right'));
-    ctx.fillStyle = earInner;
-    ctx.fill(inner);
-  });
-
-  // Head base
-  ctx.fillStyle = fringeColour;
-  ctx.beginPath();
-  ctx.ellipse(0, anatomy.head.centerY, anatomy.head.width / 2, anatomy.head.height / 2, 0, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.strokeStyle = fringeShadow;
-  ctx.lineWidth = 1.4;
-  ctx.stroke();
-
-  // Fringe layers
-  anatomy.fringe.layers.forEach((_, index) => {
-    const layerPath = new Path2D(fringeLayerPath(anatomy, index));
-    const fill = index === 0 ? fringeColour : index === 1 ? fringeHighlight : lighten(fringeColour, 0.28);
-    ctx.fillStyle = fill;
-    ctx.fill(layerPath);
-    ctx.strokeStyle = index === 0 ? darken(fringeShadow, 0.1) : 'rgba(53,38,77,0.08)';
-    ctx.lineWidth = 1.2;
-    ctx.stroke(layerPath);
-  });
-
-  const bang = new Path2D(fringeBangPath(anatomy));
-  ctx.fillStyle = fringeShadow;
-  ctx.fill(bang);
-  ctx.fillStyle = 'rgba(255,255,255,0.12)';
-  ctx.fill(new Path2D(fringeLayerPath(anatomy, Math.min(1, anatomy.fringe.layers.length - 1))));
-
-  // Muzzle
-  ctx.fillStyle = muzzleColour;
-  ctx.beginPath();
-  ctx.ellipse(0, anatomy.muzzle.y, anatomy.muzzle.width / 2, anatomy.muzzle.height / 2, 0, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.strokeStyle = darken(muzzleColour, 0.28);
-  ctx.lineWidth = 1.2;
-  ctx.stroke();
-
-  ctx.fillStyle = 'rgba(255,255,255,0.22)';
-  ctx.beginPath();
-  ctx.ellipse(
-    0,
-    anatomy.muzzle.y - anatomy.muzzle.height * 0.2,
-    anatomy.muzzle.width * 0.32,
-    anatomy.muzzle.height * 0.26,
-    0,
-    0,
-    Math.PI * 2,
-  );
-  ctx.fill();
-
-  const nostrilColour = darken(muzzleColour, 0.4);
-  [-1, 1].forEach(direction => {
-    const x = direction * anatomy.muzzle.nostrilOffset;
-    ctx.beginPath();
-    ctx.ellipse(x, anatomy.muzzle.y + anatomy.muzzle.height * 0.04, 3.2, 4.6, 0, 0, Math.PI * 2);
-    ctx.fillStyle = nostrilColour;
-    ctx.fill();
-  });
-
-  ctx.strokeStyle = darken(nostrilColour, 0.1);
+  const hornGrad = ctx.createLinearGradient(-geometry.head.rx, geometry.horns.baseLeft.y, geometry.head.rx, geometry.horns.baseLeft.y - 20);
+  hornGrad.addColorStop(0, '#F1EBE3');
+  hornGrad.addColorStop(0.55, HORN_BASE);
+  hornGrad.addColorStop(1, '#BDAF9D');
+  ctx.fillStyle = hornGrad;
+  ctx.strokeStyle = 'rgba(128,111,87,0.8)';
   ctx.lineWidth = 1.6;
-  ctx.lineCap = 'round';
-  ctx.stroke(new Path2D(mouthPath(anatomy)));
-
-  // Eyes
-  const eyes = eyePositions(anatomy);
-  const eyeColour = '#35264d';
-  Object.values(eyes).forEach(x => {
-    ctx.fillStyle = eyeColour;
-    ctx.beginPath();
-    ctx.arc(x, anatomy.eyes.y, anatomy.eyes.radius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.fillStyle = 'rgba(255,255,255,0.4)';
-    ctx.beginPath();
-    ctx.arc(x - 1.2, anatomy.eyes.y - 1.4, anatomy.eyes.radius * 0.35, 0, Math.PI * 2);
-    ctx.fill();
+  ['left', 'right'].forEach(side => {
+    const hornPath = new Path2D(buildHornPath(geometry, side as 'left' | 'right'));
+    ctx.fill(hornPath);
   });
 
-  if (traits.sleepyEyes) {
-    ctx.strokeStyle = lighten(fringeColour, 0.25);
-    ctx.lineWidth = 2.3;
-    Object.values(eyes).forEach(x => {
-      ctx.beginPath();
-      ctx.arc(x, anatomy.eyes.y - anatomy.eyes.radius * 0.1, anatomy.eyes.radius, Math.PI * 0.1, Math.PI - Math.PI * 0.1);
-      ctx.stroke();
-    });
-  }
+  ctx.lineWidth = 0;
+  const earOuter = shiftHue(coat.base, -6);
+  const earInner = 'rgba(255,221,235,0.85)';
+  ctx.fillStyle = earOuter;
+  ctx.fill(new Path2D(buildEarPath(geometry.ears.left, 'left')));
+  ctx.fill(new Path2D(buildEarPath(geometry.ears.right, 'right')));
+  ctx.fillStyle = earInner;
+  ctx.fill(new Path2D(buildEarInnerPath(geometry.ears.left, 'left')));
+  ctx.fill(new Path2D(buildEarInnerPath(geometry.ears.right, 'right')));
 
-  if (traits.fancyLashes) {
-    ctx.strokeStyle = eyeColour;
-    ctx.lineWidth = 1.3;
-    Object.values(eyes).forEach(x => {
-      const top = anatomy.eyes.y - anatomy.eyes.radius - 0.6;
-      [[-2.2, -5], [0, -5.6], [2.2, -5]].forEach(([dx, dy]) => {
-        ctx.beginPath();
-        ctx.moveTo(x + dx, top);
-        ctx.lineTo(x + dx * 0.7, top + dy);
-        ctx.stroke();
-      });
-    });
-  }
-
-  if (traits.raisedBrow) {
-    ctx.strokeStyle = fringeShadow;
-    ctx.lineWidth = 1.6;
-    ctx.lineCap = 'round';
-    ['left', 'right'].forEach(side => {
-      ctx.stroke(new Path2D(browPath(anatomy, side as 'left' | 'right')));
-    });
-  }
-
-  if (traits.rosyCheeks) {
-    ctx.save();
-    ctx.globalAlpha = 0.55;
-    ctx.fillStyle = cheekColour;
-    [-1, 1].forEach(direction => {
-      const x = direction * anatomy.cheeks.spacing * 0.5;
-      ctx.beginPath();
-      ctx.arc(x, anatomy.cheeks.y, anatomy.cheeks.radius, 0, Math.PI * 2);
-      ctx.fill();
-    });
-    ctx.restore();
-  }
-
-  // Outline
-  ctx.strokeStyle = outlineColour;
-  ctx.lineWidth = 2.2;
+  const headGrad = ctx.createLinearGradient(0, geometry.head.top, 0, geometry.head.bottom);
+  headGrad.addColorStop(0, coat.light);
+  headGrad.addColorStop(1, coat.base);
+  ctx.fillStyle = headGrad;
   ctx.beginPath();
-  ctx.ellipse(0, anatomy.body.centerY, anatomy.body.rx, bodyRy, 0, 0, Math.PI * 2);
-  ctx.stroke();
+  ctx.ellipse(geometry.head.cx, geometry.head.cy, geometry.head.rx, geometry.head.ry, 0, 0, Math.PI * 2);
+  ctx.fill();
 
-  const accessoryMeta = {
-    ...options,
-    anatomy,
-    clipAboveHead: { y: clipTop, height: clipHeight },
-  } as CowVisualOptions & AccessoryRenderMeta;
-  drawAccessories(ctx, cow, accessoryMeta);
+  ctx.fillStyle = shiftHue(coat.base, -10);
+  ctx.fill(new Path2D(fringe.back));
+
+  ctx.fillStyle = eyeState === 'closed' ? shiftHue(coat.base, -4) : EYE_COLOUR;
+  if (eyeState === 'closed') {
+    ctx.strokeStyle = shiftHue(coat.base, -4);
+    ctx.lineWidth = 3;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(geometry.eyes.left.cx - geometry.eyes.left.rx, geometry.eyes.left.cy);
+    ctx.quadraticCurveTo(geometry.eyes.left.cx, geometry.eyes.left.cy + 1, geometry.eyes.left.cx + geometry.eyes.left.rx, geometry.eyes.left.cy);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(geometry.eyes.right.cx - geometry.eyes.right.rx, geometry.eyes.right.cy);
+    ctx.quadraticCurveTo(geometry.eyes.right.cx, geometry.eyes.right.cy + 1, geometry.eyes.right.cx + geometry.eyes.right.rx, geometry.eyes.right.cy);
+    ctx.stroke();
+  } else {
+    ctx.beginPath();
+    ctx.ellipse(geometry.eyes.left.cx, geometry.eyes.left.cy, geometry.eyes.left.rx, geometry.eyes.left.ry, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.ellipse(geometry.eyes.right.cx, geometry.eyes.right.cy, geometry.eyes.right.rx, geometry.eyes.right.ry, 0, 0, Math.PI * 2);
+    ctx.fill();
+    if (eyeState === 'half') {
+      ctx.fillStyle = shiftHue(coat.base, -4);
+      ctx.fill(new Path2D(buildEyeHalfPath(geometry.eyes.left.cx, geometry.eyes.left.cy, geometry.eyes.left.rx, geometry.eyes.left.ry)));
+      ctx.fill(new Path2D(buildEyeHalfPath(geometry.eyes.right.cx, geometry.eyes.right.cy, geometry.eyes.right.rx, geometry.eyes.right.ry)));
+    } else {
+      ctx.fillStyle = 'rgba(255,255,255,0.7)';
+      ctx.beginPath();
+      ctx.arc(geometry.eyes.left.cx - 3, geometry.eyes.left.cy - 4, 3.2, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.beginPath();
+      ctx.arc(geometry.eyes.right.cx - 3, geometry.eyes.right.cy - 4, 3.2, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  ctx.strokeStyle = shiftHue(coat.shade, -10);
+  ctx.lineWidth = 3;
+  ctx.lineCap = 'round';
+  ctx.beginPath();
+  const leftBrow = new Path2D(buildBrowPath(geometry.eyes.left.cx, geometry.eyes.left.cy - geometry.eyes.left.ry - 6, geometry.eyes.left.rx * 0.95, 3));
+  const rightBrow = new Path2D(buildBrowPath(geometry.eyes.right.cx, geometry.eyes.right.cy - geometry.eyes.right.ry - 6, geometry.eyes.right.rx * 0.95, -3));
+  ctx.stroke(leftBrow);
+  ctx.stroke(rightBrow);
+
+  ctx.fillStyle = shiftHue(coat.light, -8);
+  ctx.fill(new Path2D(fringe.front));
+
+  const snoutGrad = ctx.createLinearGradient(0, geometry.snout.cy - geometry.snout.height * 0.5, 0, geometry.snout.cy + geometry.snout.height * 0.7);
+  snoutGrad.addColorStop(0, coat.light);
+  snoutGrad.addColorStop(1, coat.base);
+  ctx.fillStyle = snoutGrad;
+  ctx.fill(new Path2D(buildSnoutPath(geometry)));
+  ctx.fillStyle = 'rgba(255,255,255,0.35)';
+  ctx.fill(new Path2D(buildSnoutHighlightPath(geometry)));
+
+  const nostrilColour = shiftHue(coat.shade, -16);
+  ctx.fillStyle = nostrilColour;
+  ctx.beginPath();
+  ctx.ellipse(-geometry.snout.nostrilGap / 2, geometry.snout.cy + 6, geometry.snout.nostrilRadius, geometry.snout.nostrilRadius * 0.65, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.ellipse(geometry.snout.nostrilGap / 2, geometry.snout.cy + 6, geometry.snout.nostrilRadius, geometry.snout.nostrilRadius * 0.65, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  const blushOpacity = lerp(BLUSH_MIN_OPACITY, BLUSH_MAX_OPACITY, 0.6 + geometry.chonk * 0.4);
+  ctx.fillStyle = `rgba(243,177,180,${blushOpacity})`;
+  ctx.beginPath();
+  ctx.ellipse(geometry.blush.left.cx, geometry.blush.left.cy, geometry.blush.left.rx, geometry.blush.left.ry, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.ellipse(geometry.blush.right.cx, geometry.blush.right.cy, geometry.blush.right.rx, geometry.blush.right.ry, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  drawAccessoriesLayer(ctx, cow, geometry);
   ctx.restore();
 }
 
-export function svg(cow: Cow, options: CowVisualOptions = {}): string {
-  const { scale, anatomy } = computeScale(cow, options);
-  const viewBox = options.viewBox || '0 0 140 120';
-  const className = options.className ? ` ${options.className}` : '';
-  const offsetY = options.offsetY || 0;
-  const body = colourHex(cow.colour);
-  const fringeColour = colourHex(cow.colour === 'white' ? 'cream' : cow.colour);
-  const muzzleColour = lighten(body, 0.28);
-  const hornColour = lighten(body, 0.4);
-  const hoofColour = darken(body, 0.35);
-  const earOuter = darken(fringeColour, 0.08);
-  const earInner = lighten(fringeColour, 0.2);
-  const fringeShadow = darken(fringeColour, 0.18);
-  const fringeHighlight = lighten(fringeColour, 0.16);
-  const outlineColour = darken(body, 0.2);
-  const cheekColour = mixColour(fringeColour, '#f597b3', 0.55);
-  const nostrilColour = darken(muzzleColour, 0.4);
-  const traits = resolveTraits(cow, options);
-  const traitClasses = Object.entries(traits)
-    .filter(([, enabled]) => enabled)
-    .map(([key]) => ` cow-trait-${toKebabCase(key)}`)
-    .join('');
-  const personalityClass = ` cow-personality-${cow.personality.toLowerCase()}`;
-  const idleEnabled = options.animations?.idleWobble !== false;
-  const wobble = idleEnabled ? options.wobble || 0 : 0;
-  const bodyRy = anatomy.body.ry + wobble * 0.15;
-  const rootGroupClass = idleEnabled ? 'cow-root-group is-idle-wobble' : 'cow-root-group';
-  const idleClass = idleEnabled ? ' cow-art--idle-wobble' : '';
-  const hornsLeft = hornPath(anatomy, 'left');
-  const hornsRight = hornPath(anatomy, 'right');
-  const hornHighlightLeft = hornHighlightPath(anatomy, 'left');
-  const hornHighlightRight = hornHighlightPath(anatomy, 'right');
-  const earLeft = earPath(anatomy, 'left');
-  const earRight = earPath(anatomy, 'right');
-  const earInnerLeft = earInnerPath(anatomy, 'left');
-  const earInnerRight = earInnerPath(anatomy, 'right');
-  const fringeLayers = anatomy.fringe.layers.map((_, index) => fringeLayerPath(anatomy, index));
-  const fringeBang = fringeBangPath(anatomy);
-  const mouth = mouthPath(anatomy);
-  const eyes = eyePositions(anatomy);
-  const lidBase = anatomy.eyes.y - anatomy.eyes.radius * 0.1;
-  const lidPeak = lidBase - anatomy.eyes.radius * 0.8;
-  const sleepyLids = traits.sleepyEyes
-    ? `<path class="cow-eye-lid" d="M${fmt(eyes.left - anatomy.eyes.radius)} ${fmt(lidBase)} Q${fmt(eyes.left)} ${fmt(lidPeak)} ${fmt(eyes.left + anatomy.eyes.radius)} ${fmt(lidBase)}" stroke="${lighten(fringeColour, 0.25)}" stroke-width="2.3" fill="none" />
-       <path class="cow-eye-lid" d="M${fmt(eyes.right - anatomy.eyes.radius)} ${fmt(lidBase)} Q${fmt(eyes.right)} ${fmt(lidPeak)} ${fmt(eyes.right + anatomy.eyes.radius)} ${fmt(lidBase)}" stroke="${lighten(fringeColour, 0.25)}" stroke-width="2.3" fill="none" />`
-    : '';
-  const lashPaths = traits.fancyLashes
-    ? [-1, 1]
-        .map(direction => {
-          const cx = direction === -1 ? eyes.left : eyes.right;
-          const base = anatomy.eyes.y - anatomy.eyes.radius - 0.6;
-          return [
-            `<path d="M${fmt(cx - 2.2)},${fmt(base)} L${fmt(cx - 1.54)},${fmt(base - 5)}" stroke="#35264d" stroke-width="1.3" stroke-linecap="round" fill="none" />`,
-            `<path d="M${fmt(cx)},${fmt(base)} L${fmt(cx)},${fmt(base - 5.6)}" stroke="#35264d" stroke-width="1.3" stroke-linecap="round" fill="none" />`,
-            `<path d="M${fmt(cx + 2.2)},${fmt(base)} L${fmt(cx + 1.54)},${fmt(base - 5)}" stroke="#35264d" stroke-width="1.3" stroke-linecap="round" fill="none" />`,
-          ].join('');
-        })
-        .join('')
-    : '';
-  const browGroup = traits.raisedBrow
-    ? `<g class="cow-brows" stroke="${fringeShadow}" stroke-width="1.6" stroke-linecap="round" fill="none">
-         <path d="${browPath(anatomy, 'left')}" />
-         <path d="${browPath(anatomy, 'right')}" />
-       </g>`
-    : '';
-  const cheeksGroup = traits.rosyCheeks
-    ? `<g class="cow-cheeks" fill="${cheekColour}" opacity="0.55">
-         <circle cx="${fmt(-anatomy.cheeks.spacing * 0.5)}" cy="${fmt(anatomy.cheeks.y)}" r="${fmt(anatomy.cheeks.radius)}" />
-         <circle cx="${fmt(anatomy.cheeks.spacing * 0.5)}" cy="${fmt(anatomy.cheeks.y)}" r="${fmt(anatomy.cheeks.radius)}" />
-       </g>`
-    : '';
-  const hooves = [-1, 1]
-    .map(direction => {
-      const cx = fmt(direction * anatomy.hooves.spacing * 0.5);
-      return `
-        <g class="cow-hoof">
-          <ellipse cx="${cx}" cy="${fmt(anatomy.hooves.y)}" rx="${fmt(anatomy.hooves.width)}" ry="${fmt(anatomy.hooves.height)}" fill="${hoofColour}" />
-          <ellipse cx="${cx}" cy="${fmt(anatomy.hooves.y - anatomy.hooves.height * 0.25)}" rx="${fmt(anatomy.hooves.width * 0.7)}" ry="${fmt(anatomy.hooves.height * 0.45)}" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="1.1" />
-        </g>`;
-    })
-    .join('');
-  const sanitizedId = (cow.id || 'cow')
-    .toString()
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]/g, '-');
-  const clipId = `cow-accessory-clip-${sanitizedId}`;
-  const clipTop = Math.min(anatomy.horns.tipY - 12, anatomy.head.centerY - anatomy.head.height * 0.5);
-  const clipBottom = anatomy.head.centerY - anatomy.head.height * 0.05;
-  const clipHeight = Math.max(0.1, clipBottom - clipTop);
-  const accessoryMeta = {
-    anatomy,
-    clipAboveHead: { y: clipTop, height: clipHeight },
-    clipPathId: clipId,
-  } as AccessoryRenderMeta;
-  const accessories = accessoriesSVG(cow, accessoryMeta);
+function clearBlink(container: HTMLElement): void {
+  const timers = blinkControllers.get(container);
+  if (!timers) return;
+  if (typeof window !== 'undefined') {
+    if (timers.open) window.clearTimeout(timers.open);
+    if (timers.close) window.clearTimeout(timers.close);
+  }
+  blinkControllers.delete(container);
+}
 
-  return `
-          <svg class="cow-art${className}${personalityClass}${traitClasses}${idleClass}" viewBox="${viewBox}" role="img" aria-label="${cow.name} the cow">
-            <defs>
-              <clipPath id="${clipId}">
-                <rect x="-160" y="${fmt(clipTop)}" width="320" height="${fmt(clipHeight)}" />
-              </clipPath>
-            </defs>
-            <g transform="translate(70 ${60 + offsetY}) scale(${scale.toFixed(3)})">
-              <g class="${rootGroupClass}">
-                <g class="cow-body">
-                  <ellipse class="cow-body-fill" cx="0" cy="${fmt(anatomy.body.centerY)}" rx="${fmt(anatomy.body.rx)}" ry="${fmt(bodyRy)}" fill="${body}" />
-                  <ellipse class="cow-body-highlight" cx="0" cy="${fmt(anatomy.body.centerY - anatomy.body.ry * 0.2)}" rx="${fmt(anatomy.body.highlightRx)}" ry="${fmt(anatomy.body.highlightRy)}" fill="rgba(255,255,255,0.16)" />
-                  <ellipse class="cow-body-shade" cx="0" cy="${fmt(anatomy.body.centerY + anatomy.body.ry * 0.4)}" rx="${fmt(anatomy.body.rx * 0.7)}" ry="${fmt(bodyRy * 0.5)}" fill="rgba(0,0,0,0.08)" />
-                  <ellipse class="cow-body-outline" cx="0" cy="${fmt(anatomy.body.centerY)}" rx="${fmt(anatomy.body.rx)}" ry="${fmt(bodyRy)}" fill="none" stroke="${outlineColour}" stroke-width="2.2" />
-                </g>
-                <g class="cow-hooves">
-                  ${hooves}
-                </g>
-                <g class="cow-horns">
-                  <path d="${hornsLeft}" fill="${hornColour}" stroke="${darken(hornColour, 0.2)}" stroke-width="1.6" />
-                  <path d="${hornsRight}" fill="${hornColour}" stroke="${darken(hornColour, 0.2)}" stroke-width="1.6" />
-                  <path d="${hornHighlightLeft}" stroke="rgba(255,255,255,0.45)" stroke-width="1.4" stroke-linecap="round" fill="none" />
-                  <path d="${hornHighlightRight}" stroke="rgba(255,255,255,0.45)" stroke-width="1.4" stroke-linecap="round" fill="none" />
-                </g>
-                <g class="cow-ears">
-                  <path d="${earLeft}" fill="${earOuter}" stroke="${darken(earOuter, 0.12)}" stroke-width="1.2" />
-                  <path d="${earRight}" fill="${earOuter}" stroke="${darken(earOuter, 0.12)}" stroke-width="1.2" />
-                  <path d="${earInnerLeft}" fill="${earInner}" />
-                  <path d="${earInnerRight}" fill="${earInner}" />
-                </g>
-                <g class="cow-head">
-                  <ellipse cx="0" cy="${fmt(anatomy.head.centerY)}" rx="${fmt(anatomy.head.width / 2)}" ry="${fmt(anatomy.head.height / 2)}" fill="${fringeColour}" stroke="${fringeShadow}" stroke-width="1.4" />
-                  <path class="cow-fringe-layer" d="${fringeLayers[0]}" fill="${fringeColour}" stroke="${darken(fringeShadow, 0.1)}" stroke-width="1.2" />
-                  <path class="cow-fringe-layer" d="${fringeLayers[1]}" fill="${fringeHighlight}" stroke="rgba(53,38,77,0.08)" stroke-width="1.2" />
-                  <path class="cow-fringe-layer" d="${fringeLayers[2]}" fill="${lighten(fringeColour, 0.28)}" stroke="rgba(53,38,77,0.08)" stroke-width="1" />
-                  <path class="cow-fringe-bang" d="${fringeBang}" fill="${fringeShadow}" />
-                </g>
-                <g class="cow-muzzle">
-                  <ellipse cx="0" cy="${fmt(anatomy.muzzle.y)}" rx="${fmt(anatomy.muzzle.width / 2)}" ry="${fmt(anatomy.muzzle.height / 2)}" fill="${muzzleColour}" stroke="${darken(muzzleColour, 0.28)}" stroke-width="1.2" />
-                  <ellipse cx="0" cy="${fmt(anatomy.muzzle.y - anatomy.muzzle.height * 0.2)}" rx="${fmt(anatomy.muzzle.width * 0.32)}" ry="${fmt(anatomy.muzzle.height * 0.26)}" fill="rgba(255,255,255,0.22)" />
-                  <ellipse cx="${fmt(-anatomy.muzzle.nostrilOffset)}" cy="${fmt(anatomy.muzzle.y + anatomy.muzzle.height * 0.04)}" rx="3.2" ry="4.6" fill="${nostrilColour}" />
-                  <ellipse cx="${fmt(anatomy.muzzle.nostrilOffset)}" cy="${fmt(anatomy.muzzle.y + anatomy.muzzle.height * 0.04)}" rx="3.2" ry="4.6" fill="${nostrilColour}" />
-                  <path d="${mouth}" stroke="${darken(nostrilColour, 0.1)}" stroke-width="1.6" stroke-linecap="round" fill="none" />
-                </g>
-                <g class="cow-eyes">
-                  <circle cx="${fmt(eyes.left)}" cy="${fmt(anatomy.eyes.y)}" r="${fmt(anatomy.eyes.radius)}" fill="#35264d" />
-                  <circle cx="${fmt(eyes.right)}" cy="${fmt(anatomy.eyes.y)}" r="${fmt(anatomy.eyes.radius)}" fill="#35264d" />
-                  <circle cx="${fmt(eyes.left - 1.2)}" cy="${fmt(anatomy.eyes.y - 1.4)}" r="${fmt(anatomy.eyes.radius * 0.35)}" fill="rgba(255,255,255,0.4)" />
-                  <circle cx="${fmt(eyes.right - 1.2)}" cy="${fmt(anatomy.eyes.y - 1.4)}" r="${fmt(anatomy.eyes.radius * 0.35)}" fill="rgba(255,255,255,0.4)" />
-                  ${sleepyLids}
-                  ${lashPaths}
-                </g>
-                ${cheeksGroup}
-                ${browGroup}
-                ${accessories}
-              </g>
-            </g>
-          </svg>`;
+function scheduleBlink(container: HTMLElement, svgEl: SVGElement): void {
+  if (typeof window === 'undefined') return;
+  const state = { open: 0, close: 0 };
+  const queue = () => {
+    state.open = window.setTimeout(() => {
+      if (!svgEl.isConnected) return;
+      svgEl.classList.add('auto-blink');
+      state.close = window.setTimeout(() => {
+        svgEl.classList.remove('auto-blink');
+        queue();
+      }, BLINK_DURATION);
+      blinkControllers.set(container, { open: state.open, close: state.close });
+    }, BLINK_GAP_MIN + Math.random() * (BLINK_GAP_MAX - BLINK_GAP_MIN));
+    blinkControllers.set(container, { open: state.open, close: state.close });
+  };
+  queue();
+}
+
+export function renderCowInto(container: HTMLElement, cow: Cow, opts: CowSvgOptions = {}): SVGElement | null {
+  const pose: CowPose = opts.pose || 'idle';
+  const markup = svg(cow, opts);
+  container.innerHTML = markup;
+  container.classList.add('cow-svg');
+  container.classList.remove('pose-idle', 'pose-walk', 'pose-blink');
+  container.classList.remove('chonk-0', 'chonk-1', 'chonk-2', 'chonk-3', 'chonk-4');
+  container.classList.add(`pose-${pose}`, `chonk-${chonkBucket(cow.chonk)}`);
+  const svgEl = container.querySelector('svg');
+  if (!svgEl) return null;
+  clearBlink(container);
+  svgEl.classList.remove('auto-blink');
+  if (pose !== 'blink') {
+    scheduleBlink(container, svgEl);
+  }
+  return svgEl;
 }

--- a/highland-cow-farm/src/styles/theme.css
+++ b/highland-cow-farm/src/styles/theme.css
@@ -1,24 +1,26 @@
 :root {
-      --bg: #f7f3f9;
-      --bg-alt: #ffffff;
-      --text: #35264d;
-      --text-muted: #6a5f7c;
-      --accent: #f2a9b7;
-      --accent-strong: #f08093;
-      --accent-contrast: #fff5f7;
-      --outline: rgba(53, 38, 77, 0.1);
-      --success: #8ac6a4;
-      --warning: #f7c36a;
-      --danger: #f4876d;
-      --card-radius: 20px;
-      --transition: 0.2s ease;
-      --sky-top: #fdf6ff;
-      --sky-bottom: #dcefff;
-      --sky-glow: rgba(255, 220, 235, 0.65);
-      --field-main: #cde9bd;
-      --field-highlight: #b9ddb1;
-      --hill-shadow: #a3d3a0;
-      --cloud-color: rgba(255, 255, 255, 0.9);
+      --bg: #fef8ff;
+      --bg-alt: rgba(255, 255, 255, 0.94);
+      --text: #3d2b4f;
+      --text-muted: #77688d;
+      --accent: #f5a6c8;
+      --accent-strong: #f07fb0;
+      --accent-contrast: #fff2f8;
+      --outline: rgba(61, 43, 79, 0.14);
+      --success: #8ed1b0;
+      --warning: #fcd68a;
+      --danger: #f78c82;
+      --card-radius: 26px;
+      --card-shadow: 0 24px 48px rgba(97, 73, 116, 0.16);
+      --card-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.82);
+      --transition: 0.25s ease;
+      --sky-top: #fff2fa;
+      --sky-bottom: #d6efff;
+      --sky-glow: rgba(254, 214, 241, 0.72);
+      --field-main: #d8f5e0;
+      --field-highlight: #c9efd6;
+      --hill-shadow: #b4e4cc;
+      --cloud-color: rgba(255, 255, 255, 0.92);
       --cow-colour-rose-bg: linear-gradient(140deg, rgba(255, 236, 246, 0.95) 0%, rgba(244, 188, 213, 0.75) 100%);
       --cow-colour-rose-border: rgba(239, 153, 197, 0.6);
       --cow-colour-rose-glow: rgba(239, 153, 197, 0.4);
@@ -37,7 +39,8 @@
       color-scheme: only light;
     }
 
-    body.high-contrast {
+    body.high-contrast,
+    body.hc-high-contrast {
       --bg: #ffffff;
       --bg-alt: #f4f4f4;
       --text: #111111;
@@ -82,14 +85,15 @@
       font-family: "Nunito", "Segoe UI", system-ui, -apple-system, sans-serif;
       background-color: var(--bg);
       background-image:
-        radial-gradient(circle at 20% -10%, var(--sky-glow), transparent 60%),
+        radial-gradient(160% 140% at 50% 0%, rgba(255, 218, 242, 0.42) 0%, transparent 68%),
+        radial-gradient(120% 150% at 50% 65%, rgba(204, 232, 255, 0.22) 0%, transparent 82%),
         linear-gradient(180deg, var(--sky-top) 0%, var(--sky-bottom) 55%, var(--field-highlight) 72%, var(--field-main) 100%);
       background-repeat: no-repeat;
       color: var(--text);
       min-height: 100vh;
       display: flex;
       justify-content: center;
-      padding: 20px;
+      padding: 24px;
       transition: background-color var(--transition), color var(--transition);
       position: relative;
       overflow-x: hidden;
@@ -278,6 +282,29 @@
       gap: 24px;
       position: relative;
       z-index: 1;
+      overflow: hidden;
+    }
+
+    main::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background:
+        radial-gradient(120% 120% at 50% 0%, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0) 65%),
+        radial-gradient(150% 120% at 50% 100%, rgba(242, 169, 183, 0.22) 0%, rgba(255, 255, 255, 0) 75%);
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    body.high-contrast main::before,
+    body.hc-high-contrast main::before {
+      background: none;
+    }
+
+    main > * {
+      position: relative;
+      z-index: 1;
     }
 
     h1, h2, h3, h4 {
@@ -299,17 +326,29 @@
       border-radius: 999px;
       padding: 0.75rem 1.6rem;
       font-size: 1rem;
-      font-weight: 600;
+      font-weight: 700;
       cursor: pointer;
       transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
-      box-shadow: 0 10px 20px rgba(242, 169, 183, 0.45);
+      box-shadow: 0 12px 24px rgba(242, 169, 183, 0.35);
+      position: relative;
     }
 
-    button:hover,
-    button:focus-visible {
+    button:hover {
       transform: translateY(-2px);
-      box-shadow: 0 12px 28px rgba(242, 169, 183, 0.55);
-      outline: none;
+      box-shadow: 0 16px 32px rgba(242, 169, 183, 0.45);
+    }
+
+    button:focus-visible {
+      transform: translateY(-1px);
+      outline: 2px solid var(--accent-strong);
+      outline-offset: 2px;
+      box-shadow: 0 18px 36px rgba(242, 169, 183, 0.5);
+    }
+
+    body.high-contrast button:focus-visible,
+    body.hc-high-contrast button:focus-visible {
+      outline-color: var(--text);
+      box-shadow: 0 0 0 2px var(--accent-contrast);
     }
 
     button.secondary {
@@ -458,8 +497,34 @@
       gap: 12px;
       position: relative;
       overflow: hidden;
-      box-shadow: var(--cow-card-shadow-base), var(--cow-card-shadow-outline), var(--cow-card-shadow-glow);
+      box-shadow: var(--cow-card-shadow-base), var(--cow-card-shadow-outline), var(--cow-card-shadow-glow), var(--card-highlight);
       transition: box-shadow 0.45s ease, border-color var(--transition), transform var(--transition);
+      transform: translateY(0);
+      isolation: isolate;
+    }
+
+    .cow-card::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0));
+      opacity: 0.65;
+      pointer-events: none;
+      mix-blend-mode: screen;
+      transition: opacity var(--transition);
+      z-index: 0;
+    }
+
+    .cow-card:hover,
+    .cow-card:focus-within {
+      transform: translateY(-6px);
+      box-shadow: var(--cow-card-shadow-base), 0 12px 32px rgba(97, 73, 116, 0.18), var(--cow-card-shadow-outline), var(--cow-card-shadow-glow), var(--card-highlight);
+    }
+
+    .cow-card:hover::before,
+    .cow-card:focus-within::before {
+      opacity: 0.8;
     }
 
     .cow-card[data-colour="rose"] {
@@ -523,6 +588,11 @@
       --cow-card-shadow-base: 0 0 0 2px var(--outline);
       --cow-card-shadow-outline: 0 0 0 0 transparent;
       --cow-card-shadow-glow: 0 0 0 0 transparent;
+    }
+
+    body.high-contrast .cow-card::before,
+    body.hc-high-contrast .cow-card::before {
+      opacity: 0;
     }
 
     body.high-contrast .cow-card[data-mood="content"] {
@@ -856,6 +926,20 @@
       gap: 12px;
       justify-content: space-between;
       align-items: center;
+      background: rgba(255, 255, 255, 0.55);
+      border-radius: 20px;
+      padding: 12px 18px;
+      border: 1px solid rgba(255, 255, 255, 0.7);
+      backdrop-filter: blur(8px);
+      box-shadow: 0 16px 32px rgba(53, 38, 77, 0.12);
+    }
+
+    body.high-contrast .task-header,
+    body.hc-high-contrast .task-header {
+      background: var(--bg);
+      border: 2px solid var(--outline);
+      backdrop-filter: none;
+      box-shadow: none;
     }
 
     .task-header .badge {
@@ -872,11 +956,22 @@
     }
 
     .mini-instruction {
-      background: rgba(242, 169, 183, 0.15);
-      border-radius: 18px;
-      padding: 12px 16px;
+      background: rgba(255, 255, 255, 0.5);
+      border-radius: 20px;
+      padding: 14px 18px;
       font-size: 0.95rem;
       color: var(--text);
+      border: 1px solid rgba(255, 255, 255, 0.65);
+      backdrop-filter: blur(8px);
+      box-shadow: 0 12px 26px rgba(53, 38, 77, 0.12);
+    }
+
+    body.high-contrast .mini-instruction,
+    body.hc-high-contrast .mini-instruction {
+      background: var(--bg);
+      border: 2px solid var(--outline);
+      backdrop-filter: none;
+      box-shadow: none;
     }
 
     .minigame-area {
@@ -1254,15 +1349,26 @@
     }
     details.howto summary {
       cursor: pointer;
-      font-weight: 600;
+      font-weight: 700;
       margin-bottom: 8px;
+      color: var(--text);
     }
 
     details.howto {
-      background: rgba(138, 198, 164, 0.1);
-      border-radius: 18px;
-      padding: 12px 16px;
-      border: 2px solid rgba(138, 198, 164, 0.3);
+      background: rgba(255, 255, 255, 0.55);
+      border-radius: 20px;
+      padding: 14px 18px;
+      border: 1px solid rgba(255, 255, 255, 0.7);
+      backdrop-filter: blur(8px);
+      box-shadow: 0 18px 36px rgba(53, 38, 77, 0.12);
+    }
+
+    body.high-contrast details.howto,
+    body.hc-high-contrast details.howto {
+      background: var(--bg);
+      border: 2px solid var(--outline);
+      backdrop-filter: none;
+      box-shadow: none;
     }
 
     @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- replace the emoji cow renderer with a layered Highland calf SVG that supports poses, chonk scaling, blinking and accessories, including canvas drawing helpers
- add a flower crown accessory entry with alias support so legacy IDs resolve cleanly
- soften the global theme with pastel gradients, glass panels, polished cards and updated focus states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce77f874248321baa8f29523b5eb07