### PR TITLE
Add herd journal data and interface

### DIFF
--- a/highland-cow-farm/index.html
+++ b/highland-cow-farm/index.html
@@ -135,6 +135,7 @@
       <div class="button-row">
         <button id="btn-start-day">Start Day Cycle</button>
         <button class="secondary" id="btn-farm-options">Options</button>
+        <button class="ghost" id="btn-open-journal">Open Herd Journal</button>
       </div>
     </section>
 
@@ -170,6 +171,18 @@
         <button id="btn-decor-save">Save Décor</button>
         <button class="secondary" id="btn-decor-back">Cancel</button>
       </div>
+    </section>
+
+    <section class="screen" data-screen="journal" aria-labelledby="journal-heading">
+      <header>
+        <h2 id="journal-heading">Herd Journal</h2>
+        <p>Collect little stories about each cow: outfit highlights, favourite snacks, and thoughtful notes.</p>
+      </header>
+      <div class="journal-controls">
+        <button class="secondary" id="btn-journal-back">Back to Farm</button>
+        <button class="ghost" id="btn-journal-refresh">Refresh Journal</button>
+      </div>
+      <div class="journal-grid" id="journal-cow-list" aria-live="polite"></div>
     </section>
 
     <section class="screen" data-screen="task" aria-labelledby="task-heading">

--- a/highland-cow-farm/src/assets/journal/README.md
+++ b/highland-cow-farm/src/assets/journal/README.md
@@ -1,0 +1,3 @@
+# Journal Snapshots
+
+This directory is reserved for future keepsake exports of herd journal snapshots. Runtime snapshots are stored in save data as base64 SVG strings so they can later be written out to files within this folder.

--- a/highland-cow-farm/src/game/progression.ts
+++ b/highland-cow-farm/src/game/progression.ts
@@ -1,4 +1,4 @@
-import type { Cow, SaveData, SeasonProgressSnapshot } from '../types';
+import type { Cow, CowAdjustments, SaveData, SeasonProgressSnapshot } from '../types';
 import { shuffle, sample, pick } from '../core/util';
 import * as State from '../core/state';
 import * as TaskRush from '../ui/taskRush';
@@ -496,7 +496,7 @@ function pickParticipants(cows: Cow[], count: number, plannedEvent: PlannedEvent
   return selection.concat(extras);
 }
 
-function mergeAdjustments(target: SummaryUI.SummaryData['adjustments'], addition: Record<string, any>) {
+function mergeAdjustments(target: CowAdjustments, addition: CowAdjustments) {
   if (!addition) return;
   Object.keys(addition).forEach(id => {
     const source = addition[id];
@@ -507,6 +507,13 @@ function mergeAdjustments(target: SummaryUI.SummaryData['adjustments'], addition
         dest[key] = (dest[key] || 0) + source[key];
       }
     });
+    if (Array.isArray(source.servedTreats) && source.servedTreats.length) {
+      const merged = dest.servedTreats ? dest.servedTreats.slice() : [];
+      dest.servedTreats = merged.concat(source.servedTreats);
+    }
+    if (typeof source.addAccessory === 'string' && source.addAccessory.trim()) {
+      dest.addAccessory = source.addAccessory;
+    }
   });
 }
 

--- a/highland-cow-farm/src/main.ts
+++ b/highland-cow-farm/src/main.ts
@@ -10,6 +10,7 @@ import * as StyleRoom from './ui/styleRoom';
 import * as DecorRoom from './ui/decorRoom';
 import * as TaskRush from './ui/taskRush';
 import * as SummaryUI from './ui/summary';
+import * as Journal from './ui/journal';
 import * as Progression from './game/progression';
 import type { Options, SeasonProgressSnapshot } from './types';
 
@@ -44,6 +45,9 @@ sections.forEach(section => {
       break;
     case 'summary':
       SummaryUI.init(section);
+      break;
+    case 'journal':
+      Journal.init(section);
       break;
     default:
       break;
@@ -141,6 +145,10 @@ FarmUI.configureFarmHandlers({
   },
   onManageDecor() {
     DecorRoom.show(State.getUnlocks('decor'), State.getDecorLayout());
+  },
+  onOpenJournal() {
+    Journal.refresh();
+    Journal.show();
   }
 });
 
@@ -207,6 +215,16 @@ SummaryUI.configureSummaryHandlers({
 TaskRush.configureTaskHandlers({
   onContinue() {
     // Placeholder for future manual progression controls.
+  }
+});
+
+Journal.configureJournalHandlers({
+  onBack() {
+    FarmUI.show();
+    refreshFarm();
+  },
+  onDataChanged() {
+    refreshFarm();
   }
 });
 

--- a/highland-cow-farm/src/minigames/food.ts
+++ b/highland-cow-farm/src/minigames/food.ts
@@ -189,6 +189,7 @@ function finish(success: boolean, message: string) {
   state.running = false;
   stopLoop();
   const adjustments: MiniGameResult['adjustments'] = {};
+  const treatLog: Record<string, string[]> = {};
   state.targets.forEach(target => {
     if (!adjustments[target.cow.id]) adjustments[target.cow.id] = {};
     const adj = adjustments[target.cow.id];
@@ -199,6 +200,10 @@ function finish(success: boolean, message: string) {
       const chonkChange = typeof foodMeta.chonk === 'number' ? foodMeta.chonk : 0;
       adj.hunger = (adj.hunger || 0) + hungerChange;
       adj.happiness = (adj.happiness || 0) + happinessChange;
+      if (target.food?.name) {
+        if (!treatLog[target.cow.id]) treatLog[target.cow.id] = [];
+        treatLog[target.cow.id].push(target.food.name);
+      }
       if (chonkChange) {
         adj.chonk = (adj.chonk || 0) + chonkChange;
       }
@@ -212,6 +217,12 @@ function finish(success: boolean, message: string) {
       adj.chonk = (adj.chonk || 0) + overfeedChonk;
       adj.happiness = (adj.happiness || 0) - overfeedMood;
     }
+  });
+  Object.keys(treatLog).forEach(id => {
+    const entry = adjustments[id];
+    if (!entry) return;
+    const list = entry.servedTreats || [];
+    entry.servedTreats = list.concat(treatLog[id]);
   });
   const treatNames = Array.from(new Set(state.targets.filter(t => t.satisfied && t.food).map(t => t.food!.name)));
   let summary = message || '';

--- a/highland-cow-farm/src/minigames/types.ts
+++ b/highland-cow-farm/src/minigames/types.ts
@@ -1,4 +1,4 @@
-import type { Cow, Options } from '../types';
+import type { Cow, CowAdjustments, Options } from '../types';
 
 export type MiniGameKey = 'catch' | 'food' | 'brush' | 'ceilidh';
 
@@ -15,7 +15,7 @@ export interface MiniGameContext {
 
 export interface MiniGameResult {
   success: boolean;
-  adjustments: Record<string, Partial<Record<'happiness' | 'hunger' | 'cleanliness' | 'chonk', number>>>;
+  adjustments: CowAdjustments;
   summary?: string;
   stats?: { totalPerfects?: number; totalChonks?: number };
 }

--- a/highland-cow-farm/src/styles/theme.css
+++ b/highland-cow-farm/src/styles/theme.css
@@ -1584,6 +1584,223 @@
       box-shadow: none;
     }
 
+    .journal-controls {
+      display: flex;
+      gap: 12px;
+      margin: 18px 0 22px;
+      flex-wrap: wrap;
+    }
+
+    .journal-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 22px;
+      margin-bottom: 24px;
+    }
+
+    .journal-card {
+      background: rgba(255, 255, 255, 0.78);
+      border-radius: var(--card-radius);
+      padding: 20px 22px;
+      box-shadow: var(--card-shadow);
+      backdrop-filter: blur(10px);
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    body.high-contrast .journal-card,
+    body.hc-high-contrast .journal-card {
+      background: var(--bg);
+      box-shadow: none;
+      border: 2px solid var(--outline);
+      backdrop-filter: none;
+    }
+
+    .journal-card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 16px;
+    }
+
+    .journal-cow-art {
+      width: min(160px, 30vw);
+      height: auto;
+      display: block;
+    }
+
+    .journal-subtitle {
+      margin: 4px 0 0;
+      font-size: 0.95rem;
+      color: var(--text-muted);
+    }
+
+    .journal-message {
+      min-height: 1.2em;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+    }
+
+    .journal-message[data-state='success'] {
+      color: var(--success);
+    }
+
+    .journal-message[data-state='error'] {
+      color: var(--danger);
+    }
+
+    .journal-stats {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 8px;
+      padding: 10px 12px;
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.65);
+      text-align: center;
+      font-size: 0.9rem;
+    }
+
+    .journal-stats strong {
+      display: block;
+      margin-bottom: 4px;
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--text-muted);
+    }
+
+    .journal-section {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .journal-section h4 {
+      margin: 0;
+      font-size: 1rem;
+    }
+
+    .journal-list,
+    .journal-notes-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .journal-list li,
+    .journal-notes-list li {
+      background: rgba(255, 255, 255, 0.7);
+      border-radius: 14px;
+      padding: 8px 12px;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    .journal-list li span {
+      color: var(--text-muted);
+      font-size: 0.85rem;
+    }
+
+    .journal-empty {
+      margin: 0;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+    }
+
+    .journal-treats {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .journal-treat {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.75);
+      font-size: 0.9rem;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+    }
+
+    .journal-treat small {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+    }
+
+    .journal-note-meta {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-bottom: 4px;
+    }
+
+    .journal-notes-list p {
+      margin: 0;
+      font-size: 0.92rem;
+    }
+
+    .journal-note-delete {
+      background: rgba(255, 255, 255, 0.6);
+      border-radius: 50%;
+      width: 28px;
+      height: 28px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.8rem;
+    }
+
+    .journal-note-form textarea,
+    .journal-rename-form input {
+      width: 100%;
+      margin-top: 4px;
+      font-size: 1rem;
+      border-radius: 12px;
+      border: 1px solid rgba(0, 0, 0, 0.08);
+      padding: 8px 10px;
+    }
+
+    body.high-contrast .journal-note-form textarea,
+    body.high-contrast .journal-rename-form input,
+    body.hc-high-contrast .journal-note-form textarea,
+    body.hc-high-contrast .journal-rename-form input {
+      border: 2px solid var(--outline);
+    }
+
+    .journal-note-form button,
+    .journal-rename-form button,
+    .journal-snapshot-btn {
+      align-self: flex-start;
+    }
+
+    .journal-snapshot {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .journal-snapshot img {
+      width: 100%;
+      max-width: 220px;
+      border-radius: 16px;
+      border: 1px solid rgba(0, 0, 0, 0.06);
+      background: var(--bg);
+      box-shadow: 0 8px 24px rgba(61, 43, 79, 0.16);
+    }
+
+    .journal-snapshot figcaption {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+    }
+
     @media (max-width: 640px) {
       body {
         padding: 12px;

--- a/highland-cow-farm/src/types.d.ts
+++ b/highland-cow-farm/src/types.d.ts
@@ -13,6 +13,44 @@ export interface Cow {
   colour: CowColour;
 }
 
+export interface CowNameRecord {
+  day: number;
+  name: string;
+  recordedISO: string;
+}
+
+export interface CowNoteEntry {
+  id: string;
+  day: number;
+  text: string;
+  recordedISO: string;
+}
+
+export interface CowOutfitEntry {
+  day: number;
+  accessories: string[];
+  recordedISO: string;
+}
+
+export interface CowSnapshotEntry {
+  day: number;
+  dataUri: string;
+  recordedISO: string;
+}
+
+export interface CowJournalEntry {
+  cowId: string;
+  names: CowNameRecord[];
+  notes: CowNoteEntry[];
+  outfits: CowOutfitEntry[];
+  favouriteTreats: Record<string, number>;
+  snapshots: CowSnapshotEntry[];
+}
+
+export interface JournalData {
+  cows: Record<string, CowJournalEntry>;
+}
+
 export interface Unlocks {
   foods: string[];
   accessories: string[];
@@ -91,6 +129,7 @@ export interface SaveData {
   version: number;
   day: number;
   cows: Cow[];
+  journal: JournalData;
   unlocks: Unlocks;
   activeDecor: string[];
   decorLayout: DecorLayout;
@@ -103,10 +142,21 @@ export interface SaveData {
 
 export interface MiniGameOutcome {
   success: boolean;
-  adjustments: Record<string, Partial<Record<'happiness' | 'hunger' | 'cleanliness' | 'chonk', number>>>;
+  adjustments: CowAdjustments;
   summary?: string;
   stats?: { totalPerfects?: number; totalChonks?: number };
 }
+
+export interface CowAdjustment {
+  happiness?: number;
+  hunger?: number;
+  cleanliness?: number;
+  chonk?: number;
+  addAccessory?: string;
+  servedTreats?: string[];
+}
+
+export type CowAdjustments = Record<string, CowAdjustment>;
 
 declare module '*.b64?raw' {
   const content: string;

--- a/highland-cow-farm/src/ui/farm.ts
+++ b/highland-cow-farm/src/ui/farm.ts
@@ -12,6 +12,7 @@ interface FarmHandlers {
   onOptions?: () => void;
   onEditCow?: (cowId: string) => void;
   onManageDecor?: () => void;
+  onOpenJournal?: () => void;
 }
 
 let handlers: FarmHandlers = {};
@@ -119,6 +120,7 @@ export function init(section: HTMLElement): void {
   const startDayButton = section.querySelector<HTMLButtonElement>('#btn-start-day');
   const optionsButton = section.querySelector<HTMLButtonElement>('#btn-farm-options');
   const decorButton = section.querySelector<HTMLButtonElement>('#btn-manage-decor');
+  const journalButton = section.querySelector<HTMLButtonElement>('#btn-open-journal');
 
   startDayButton?.addEventListener('click', () => {
     handlers.onStartDay?.();
@@ -130,6 +132,10 @@ export function init(section: HTMLElement): void {
 
   decorButton?.addEventListener('click', () => {
     handlers.onManageDecor?.();
+  });
+
+  journalButton?.addEventListener('click', () => {
+    handlers.onOpenJournal?.();
   });
 
   herdGrid?.addEventListener('click', event => {

--- a/highland-cow-farm/src/ui/journal.ts
+++ b/highland-cow-farm/src/ui/journal.ts
@@ -1,0 +1,311 @@
+import type { Cow, CowJournalEntry } from '../types';
+import { showScreen } from '../core/screens';
+import * as State from '../core/state';
+import { FoodLibrary } from '../data/foods';
+import { svg } from '../game/cowVisuals';
+
+interface JournalHandlers {
+  onBack?: () => void;
+  onDataChanged?: () => void;
+}
+
+let handlers: JournalHandlers = {};
+let initialised = false;
+let listEl: HTMLElement | null = null;
+let backButton: HTMLButtonElement | null = null;
+let refreshButton: HTMLButtonElement | null = null;
+
+export function configureJournalHandlers(partial: JournalHandlers): void {
+  handlers = Object.assign({}, handlers, partial);
+}
+
+function favouriteTreats(entry: CowJournalEntry): Array<{ name: string; count: number; icon: string }> {
+  const pairs = Object.entries(entry.favouriteTreats || {});
+  const sorted = pairs
+    .filter(([, count]) => typeof count === 'number' && count > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4);
+  return sorted.map(([name, count]) => {
+    const icon = FoodLibrary[name]?.icon || '🍀';
+    return { name, count, icon };
+  });
+}
+
+function formatDay(day: number | undefined): string {
+  if (!day || !Number.isFinite(day)) return 'Day ?';
+  return `Day ${Math.max(1, Math.floor(day))}`;
+}
+
+function formatTimestamp(iso: string | undefined): string {
+  if (!iso) return '';
+  try {
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  } catch (err) {
+    return '';
+  }
+}
+
+function noteMarkup(entry: CowJournalEntry): string {
+  if (!entry.notes.length) {
+    return '<p class="journal-empty">No notes yet. Leave a quick memory below.</p>';
+  }
+  return entry.notes
+    .slice()
+    .reverse()
+    .map(note => {
+      const dateLabel = `${formatDay(note.day)} ${formatTimestamp(note.recordedISO)}`.trim();
+      const meta = dateLabel ? `<span class="journal-note-meta">${dateLabel}</span>` : '';
+      return `<li data-note="${note.id}"><div>${meta}<p>${note.text.replace(/</g, '&lt;')}</p></div><button type="button" class="ghost journal-note-delete" data-note="${note.id}" aria-label="Delete note">✖</button></li>`;
+    })
+    .join('');
+}
+
+function outfitSummary(entry: CowJournalEntry): string {
+  if (!entry.outfits.length) {
+    return '<p class="journal-empty">No outfits recorded yet.</p>';
+  }
+  return entry.outfits
+    .slice()
+    .reverse()
+    .slice(0, 5)
+    .map(outfit => {
+      const accessories = outfit.accessories.length ? outfit.accessories.join(', ') : 'No accessories';
+      const dateLabel = `${formatDay(outfit.day)} ${formatTimestamp(outfit.recordedISO)}`.trim();
+      return `<li><strong>${dateLabel || 'Recent'}</strong><span>${accessories}</span></li>`;
+    })
+    .join('');
+}
+
+function renameHistory(entry: CowJournalEntry): string {
+  if (!entry.names.length) {
+    return '<p class="journal-empty">No custom names yet.</p>';
+  }
+  return entry.names
+    .slice()
+    .reverse()
+    .slice(0, 5)
+    .map(record => {
+      const label = `${formatDay(record.day)} ${formatTimestamp(record.recordedISO)}`.trim();
+      return `<li><strong>${record.name}</strong><span>${label || ''}</span></li>`;
+    })
+    .join('');
+}
+
+function snapshotPreview(entry: CowJournalEntry): string {
+  if (!entry.snapshots.length) {
+    return '<p class="journal-empty">No snapshots yet. Capture today\'s look!</p>';
+  }
+  const latest = entry.snapshots[entry.snapshots.length - 1];
+  const label = `${formatDay(latest.day)} ${formatTimestamp(latest.recordedISO)}`.trim();
+  return `<figure class="journal-snapshot"><img src="${latest.dataUri}" alt="Recent look" /><figcaption>${label || 'Latest look'}</figcaption></figure>`;
+}
+
+function buildCard(cow: Cow, entry: CowJournalEntry, day: number): HTMLElement {
+  const card = document.createElement('article');
+  card.className = 'journal-card';
+  card.dataset.cow = cow.id;
+  const treats = favouriteTreats(entry);
+  const treatMarkup = treats.length
+    ? treats
+        .map(item => `<span class="journal-treat">${item.icon} ${item.name}<small>x${item.count}</small></span>`)
+        .join('')
+    : '<span class="journal-empty">No favourite treats logged yet.</span>';
+  card.innerHTML = `
+    <header class="journal-card-header">
+      <div>
+        <h3>${cow.name}</h3>
+        <p class="journal-subtitle">${cow.personality} • ${formatDay(day)}</p>
+      </div>
+      <div class="journal-art" aria-hidden="true">${svg(cow, { className: 'journal-cow-art', scale: 1.05, viewBox: '0 0 160 130' })}</div>
+    </header>
+    <div class="journal-message" role="status" aria-live="polite"></div>
+    <section class="journal-stats">
+      <div><strong>Happiness</strong><span>${Math.round(cow.happiness)}</span></div>
+      <div><strong>Hunger</strong><span>${Math.round(cow.hunger)}</span></div>
+      <div><strong>Cleanliness</strong><span>${Math.round(cow.cleanliness)}</span></div>
+      <div><strong>Chonk</strong><span>${Math.round(cow.chonk)}</span></div>
+    </section>
+    <section class="journal-section">
+      <h4>Rename History</h4>
+      <ul class="journal-list">${renameHistory(entry)}</ul>
+      <form class="journal-rename-form" data-cow="${cow.id}">
+        <label>Rename ${cow.name}
+          <input type="text" name="name" maxlength="24" value="${cow.name}" />
+        </label>
+        <button type="submit">Save Name</button>
+      </form>
+    </section>
+    <section class="journal-section">
+      <h4>Accessory Moments</h4>
+      <ul class="journal-list journal-outfits">${outfitSummary(entry)}</ul>
+      <button type="button" class="ghost journal-snapshot-btn" data-cow="${cow.id}">Take Snapshot</button>
+      <div class="journal-snapshot-area">${snapshotPreview(entry)}</div>
+    </section>
+    <section class="journal-section">
+      <h4>Favourite Treats</h4>
+      <div class="journal-treats">${treatMarkup}</div>
+    </section>
+    <section class="journal-section journal-notes">
+      <h4>Notes</h4>
+      <ul class="journal-notes-list">${noteMarkup(entry)}</ul>
+      <form class="journal-note-form" data-cow="${cow.id}">
+        <label>Add a note
+          <textarea name="note" maxlength="280" rows="2" placeholder="Sweet moment, cosy detail, future plan..."></textarea>
+        </label>
+        <button type="submit">Add Note</button>
+      </form>
+    </section>
+  `;
+  return card;
+}
+
+function setMessage(card: HTMLElement, message: string, variant: 'success' | 'error' = 'success'): void {
+  const messageEl = card.querySelector<HTMLElement>('.journal-message');
+  if (!messageEl) return;
+  messageEl.textContent = message;
+  messageEl.dataset.state = variant;
+}
+
+function render(): void {
+  if (!listEl) return;
+  const data = State.getData();
+  const journal = State.getJournal();
+  const fragment = document.createDocumentFragment();
+  data.cows.forEach(cow => {
+    const entry = journal.cows[cow.id] || (State.getCowJournal(cow.id) as CowJournalEntry);
+    fragment.appendChild(buildCard(cow, entry, data.day));
+  });
+  listEl.innerHTML = '';
+  listEl.appendChild(fragment);
+}
+
+function handleRename(form: HTMLFormElement): void {
+  const cowId = form.dataset.cow;
+  if (!cowId) return;
+  const input = form.querySelector<HTMLInputElement>('input[name="name"]');
+  if (!input) return;
+  const card = form.closest<HTMLElement>('.journal-card');
+  const result = State.renameCow(cowId, input.value);
+  if (!card) return;
+  if (!result.success) {
+    setMessage(card, result.message || 'Could not rename cow.', 'error');
+    return;
+  }
+  setMessage(card, 'Name updated!', 'success');
+  handlers.onDataChanged?.();
+  render();
+}
+
+function handleNote(form: HTMLFormElement): void {
+  const cowId = form.dataset.cow;
+  if (!cowId) return;
+  const textarea = form.querySelector<HTMLTextAreaElement>('textarea[name="note"]');
+  if (!textarea) return;
+  const card = form.closest<HTMLElement>('.journal-card');
+  const result = State.addCowNote(cowId, textarea.value);
+  if (!card) return;
+  if (!result.success) {
+    setMessage(card, result.message || 'Could not save note.', 'error');
+    return;
+  }
+  textarea.value = '';
+  setMessage(card, 'Note saved.', 'success');
+  handlers.onDataChanged?.();
+  render();
+}
+
+function handleNoteDelete(button: HTMLButtonElement): void {
+  const cowId = button.closest<HTMLElement>('.journal-card')?.dataset.cow;
+  const noteId = button.dataset.note;
+  if (!cowId || !noteId) return;
+  const result = State.removeCowNote(cowId, noteId);
+  const card = button.closest<HTMLElement>('.journal-card');
+  if (!card) return;
+  if (!result.success) {
+    setMessage(card, result.message || 'Could not remove note.', 'error');
+    return;
+  }
+  setMessage(card, 'Note removed.', 'success');
+  handlers.onDataChanged?.();
+  render();
+}
+
+function handleSnapshot(button: HTMLButtonElement): void {
+  const cowId = button.dataset.cow;
+  if (!cowId) return;
+  const cow = State.getCow(cowId);
+  const card = button.closest<HTMLElement>('.journal-card');
+  if (!cow || !card) return;
+  try {
+    const markup = svg(cow, { className: 'journal-cow-art', scale: 1.05, viewBox: '0 0 160 130' });
+    const encoded = window.btoa(unescape(encodeURIComponent(markup)));
+    const dataUri = `data:image/svg+xml;base64,${encoded}`;
+    const result = State.recordCowSnapshotEntry(cowId, dataUri);
+    if (!result.success) {
+      setMessage(card, result.message || 'Snapshot failed.', 'error');
+      return;
+    }
+    setMessage(card, 'Snapshot saved!', 'success');
+    handlers.onDataChanged?.();
+    render();
+  } catch (err) {
+    console.warn('Snapshot failed', err);
+    setMessage(card, 'Snapshot failed to generate.', 'error');
+  }
+}
+
+export function init(section: HTMLElement): void {
+  if (initialised) return;
+  initialised = true;
+  listEl = section.querySelector<HTMLElement>('#journal-cow-list');
+  backButton = section.querySelector<HTMLButtonElement>('#btn-journal-back');
+  refreshButton = section.querySelector<HTMLButtonElement>('#btn-journal-refresh');
+
+  backButton?.addEventListener('click', () => {
+    handlers.onBack?.();
+  });
+
+  refreshButton?.addEventListener('click', () => {
+    render();
+  });
+
+  listEl?.addEventListener('submit', event => {
+    const form = (event.target as HTMLElement).closest<HTMLFormElement>('form');
+    if (!form) return;
+    if (form.classList.contains('journal-rename-form')) {
+      event.preventDefault();
+      handleRename(form);
+    } else if (form.classList.contains('journal-note-form')) {
+      event.preventDefault();
+      handleNote(form);
+    }
+  });
+
+  listEl?.addEventListener('click', event => {
+    const target = event.target as HTMLElement;
+    const deleteButton = target.closest<HTMLButtonElement>('.journal-note-delete');
+    if (deleteButton) {
+      event.preventDefault();
+      handleNoteDelete(deleteButton);
+      return;
+    }
+    const snapshotButton = target.closest<HTMLButtonElement>('.journal-snapshot-btn');
+    if (snapshotButton) {
+      event.preventDefault();
+      handleSnapshot(snapshotButton);
+    }
+  });
+}
+
+export function show(): void {
+  if (!initialised) return;
+  render();
+  showScreen('journal');
+}
+
+export function refresh(): void {
+  if (!initialised) return;
+  render();
+}

--- a/highland-cow-farm/src/ui/summary.ts
+++ b/highland-cow-farm/src/ui/summary.ts
@@ -1,4 +1,4 @@
-import type { Cow, SeasonProgressSnapshot } from '../types';
+import type { Cow, CowAdjustments, SeasonProgressSnapshot } from '../types';
 import { showScreen } from '../core/screens';
 import { FoodLibrary } from '../data/foods';
 import { AccessoryLibrary } from '../data/accessories';
@@ -12,7 +12,7 @@ interface SummaryHandlers {
 
 export interface SummaryData {
   results: Array<{ name: string; success: boolean; summary: string; icon?: string; key?: MiniGameKey }>;
-  adjustments: Record<string, Partial<Record<'happiness' | 'hunger' | 'cleanliness' | 'chonk', number>>>;
+  adjustments: CowAdjustments;
   herd: Cow[];
   reward?: {
     type: 'foods' | 'accessories' | 'decor';


### PR DESCRIPTION
## Summary
- add journal data structures and persistence hooks for rename history, notes, outfit snapshots, and treat tracking
- build a herd journal screen with rename/note controls, treat highlights, and snapshot capture wired into the farm flow
- track treat usage from the food mini-game and update shared types/styles for the new journal experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c6fd417c832189661820c2a934ff