### PR TITLE
Add family challenge mode with co-op tracking

### DIFF
--- a/highland-cow-farm/index.html
+++ b/highland-cow-farm/index.html
@@ -93,6 +93,10 @@
           <label for="toggle-reduced">Reduce flashing effects</label>
           <input type="checkbox" id="toggle-reduced" />
         </div>
+        <div class="toggle">
+          <label for="toggle-family-challenge">Family Challenge mode</label>
+          <input type="checkbox" id="toggle-family-challenge" />
+        </div>
       </div>
       <div class="button-row">
         <button class="secondary" id="btn-options-back">Back</button>
@@ -116,6 +120,7 @@
       <section class="farm-meta">
         <article class="farm-panel">
           <h3>Daily Moodlets</h3>
+          <div class="challenge-status" id="family-challenge-status" hidden></div>
           <ul class="event-list" id="farm-events"></ul>
         </article>
         <article class="farm-panel">

--- a/highland-cow-farm/src/data/achievements.ts
+++ b/highland-cow-farm/src/data/achievements.ts
@@ -23,5 +23,9 @@ export const ACHIEVEMENTS: Record<string, AchievementEntry> = {
   chonkSentinel: {
     title: 'Chonk Sentinel',
     description: 'End a day with every cow below 70 chonk.'
+  },
+  familyHarmony: {
+    title: 'Family Harmony',
+    description: 'Share a perfect day together in Family Challenge mode.'
   }
 };

--- a/highland-cow-farm/src/main.ts
+++ b/highland-cow-farm/src/main.ts
@@ -101,8 +101,9 @@ function refreshFarm(): void {
   FarmUI.renderAchievements(State.getAchievements());
   const preview = Progression.getPreviewPlan(data);
   const seasonContext = preview?.season || State.getSeasonContext(data.day);
+  const challengeOverview = State.getFamilyChallengeOverview();
   updateSeasonStyles(seasonContext);
-  FarmUI.renderEvents(preview?.previewNotes || [], seasonContext);
+  FarmUI.renderEvents(preview?.previewNotes || [], seasonContext, challengeOverview);
   if (data.options.audioOn) {
     ensureAmbience();
   } else {

--- a/highland-cow-farm/src/styles/theme.css
+++ b/highland-cow-farm/src/styles/theme.css
@@ -755,6 +755,19 @@
       color: var(--text-muted);
     }
 
+    .challenge-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 12px;
+      border-radius: 12px;
+      background: rgba(138, 198, 164, 0.22);
+      border: 1px solid rgba(138, 198, 164, 0.4);
+      font-size: 0.9rem;
+      color: var(--text);
+      margin-bottom: 8px;
+    }
+
     .achievement-list li.completed::marker {
       content: "🌟 ";
     }
@@ -1522,6 +1535,70 @@
       border-radius: 18px;
       background: rgba(242, 169, 183, 0.12);
       border: 2px solid rgba(53, 38, 77, 0.08);
+    }
+
+    .summary-item.summary-family {
+      background: rgba(138, 198, 164, 0.18);
+      border-color: rgba(138, 198, 164, 0.38);
+    }
+
+    .family-leaderboard {
+      margin-top: 8px;
+      display: grid;
+      gap: 6px;
+    }
+
+    .family-leaderboard-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      background: rgba(255, 255, 255, 0.85);
+      border-radius: 14px;
+      border: 1px solid rgba(53, 38, 77, 0.08);
+      font-size: 0.9rem;
+    }
+
+    .family-leaderboard-row.is-mvp {
+      border-color: rgba(240, 127, 176, 0.5);
+      box-shadow: 0 8px 20px rgba(240, 127, 176, 0.18);
+    }
+
+    .family-leaderboard-name {
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .family-leaderboard-stats {
+      color: var(--text-muted);
+      font-size: 0.85rem;
+    }
+
+    .family-leaderboard-badge {
+      display: inline-block;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: rgba(240, 127, 176, 0.18);
+      font-weight: 700;
+      font-size: 0.8rem;
+      color: var(--text);
+      text-align: center;
+    }
+
+    .family-leaderboard-badge.history {
+      background: rgba(61, 43, 79, 0.08);
+    }
+
+    .family-assignments {
+      margin: 10px 0 0;
+      padding-left: 18px;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+
+    .family-assignments li {
+      margin-bottom: 4px;
     }
 
     .summary-cow-deltas {

--- a/highland-cow-farm/src/types.d.ts
+++ b/highland-cow-farm/src/types.d.ts
@@ -1,3 +1,5 @@
+import type { MiniGameKey } from './minigames/types';
+
 export type Personality = 'Greedy' | 'Vain' | 'Sleepy' | 'Social';
 export type CowColour = 'brown' | 'cream' | 'rose' | 'chocolate' | 'white';
 
@@ -70,6 +72,72 @@ export interface Options {
   masterVolume: number;
   highContrastUI: boolean;
   reducedFlash: boolean;
+  familyChallengeMode: boolean;
+}
+
+export interface FamilyChallengeParticipant {
+  id: string;
+  name: string;
+}
+
+export interface FamilyChallengeRecord {
+  id: string;
+  name: string;
+  plays: number;
+  wins: number;
+  perfects: number;
+  score: number;
+  mvpCount: number;
+  lastPlayedDay?: number;
+  lastMvpDay?: number;
+}
+
+export interface FamilyChallengeState {
+  enabled: boolean;
+  participants: FamilyChallengeParticipant[];
+  rotationIndex: number;
+  streak: number;
+  bestStreak: number;
+  stats: Record<string, FamilyChallengeRecord>;
+  lastMvpId?: string | null;
+  mvpRotationIndex: number;
+}
+
+export interface FamilyChallengeAssignment {
+  participantId: string;
+  miniGame: MiniGameKey;
+  success: boolean;
+  perfect: boolean;
+}
+
+export interface FamilyChallengeLeaderboardEntry {
+  id: string;
+  name: string;
+  plays: number;
+  wins: number;
+  perfects: number;
+  score: number;
+  mvpCount: number;
+  isMvp?: boolean;
+}
+
+export interface FamilyChallengeDaySummary {
+  enabled: boolean;
+  assignments: Array<{ miniGame: MiniGameKey; name: string; success: boolean; perfect: boolean }>;
+  leaderboard: FamilyChallengeLeaderboardEntry[];
+  streak: number;
+  bestStreak: number;
+  mvpName?: string | null;
+  nextPlayer?: { id: string; name: string } | null;
+  unlockedAchievements?: string[];
+}
+
+export interface FamilyChallengeOverview {
+  enabled: boolean;
+  nextPlayer?: { id: string; name: string } | null;
+  streak: number;
+  bestStreak: number;
+  lastMvpName?: string | null;
 }
 
 export interface FarmStats {
@@ -138,6 +206,7 @@ export interface SaveData {
   achievements: AchievementMap;
   lastPlayedISO: string;
   season: SeasonState;
+  familyChallenge: FamilyChallengeState;
 }
 
 export interface MiniGameOutcome {

--- a/highland-cow-farm/src/ui/farm.ts
+++ b/highland-cow-farm/src/ui/farm.ts
@@ -1,4 +1,4 @@
-import type { AchievementMap, Cow, DecorLayout, SeasonProgressSnapshot } from '../types';
+import type { AchievementMap, Cow, DecorLayout, FamilyChallengeOverview, SeasonProgressSnapshot } from '../types';
 import { showScreen } from '../core/screens';
 import { AccessoryLibrary } from '../data/accessories';
 import { ACHIEVEMENTS } from '../data/achievements';
@@ -22,6 +22,7 @@ let eventsList: HTMLElement | null = null;
 let pantryList: HTMLElement | null = null;
 let decorDisplay: HTMLElement | null = null;
 let achievementList: HTMLElement | null = null;
+let challengeBadge: HTMLElement | null = null;
 
 export function configureFarmHandlers(partial: FarmHandlers): void {
   handlers = Object.assign({}, handlers, partial);
@@ -114,6 +115,7 @@ export function init(section: HTMLElement): void {
   initialised = true;
   herdGrid = section.querySelector<HTMLElement>('#herd-grid');
   eventsList = section.querySelector<HTMLElement>('#farm-events');
+  challengeBadge = section.querySelector<HTMLElement>('#family-challenge-status');
   pantryList = section.querySelector<HTMLElement>('#pantry-list');
   decorDisplay = section.querySelector<HTMLElement>('#decor-display');
   achievementList = section.querySelector<HTMLElement>('#achievement-list');
@@ -176,7 +178,11 @@ export function renderHerd(cows: Cow[]): void {
   herdGrid.appendChild(fragment);
 }
 
-export function renderEvents(events: Array<{ title?: string; detail?: string } | string>, season?: SeasonProgressSnapshot | null): void {
+export function renderEvents(
+  events: Array<{ title?: string; detail?: string } | string>,
+  season?: SeasonProgressSnapshot | null,
+  challenge?: FamilyChallengeOverview | null
+): void {
   if (!eventsList) return;
   eventsList.innerHTML = '';
   const fallback = { title: 'No special events', detail: 'A peaceful breeze across the paddock.' };
@@ -247,6 +253,25 @@ export function renderEvents(events: Array<{ title?: string; detail?: string } |
       li.appendChild(listEl);
     }
     eventsList.appendChild(li);
+  }
+
+  if (challengeBadge) {
+    if (challenge?.enabled) {
+      challengeBadge.hidden = false;
+      const streakLabel = challenge.streak === 1 ? 'day' : 'days';
+      const parts = [`Family Challenge active`];
+      if (challenge.nextPlayer) {
+        parts.push(`Next: ${challenge.nextPlayer.name}`);
+      }
+      parts.push(`Streak ${challenge.streak} ${streakLabel}`);
+      if (challenge.lastMvpName) {
+        parts.push(`MVP: ${challenge.lastMvpName}`);
+      }
+      challengeBadge.textContent = parts.join(' • ');
+    } else {
+      challengeBadge.hidden = true;
+      challengeBadge.textContent = '';
+    }
   }
 }
 

--- a/highland-cow-farm/src/ui/options.ts
+++ b/highland-cow-farm/src/ui/options.ts
@@ -11,6 +11,7 @@ let initialised = false;
 let audioToggle: HTMLInputElement | null = null;
 let contrastToggle: HTMLInputElement | null = null;
 let reducedToggle: HTMLInputElement | null = null;
+let familyToggle: HTMLInputElement | null = null;
 let masterRange: HTMLInputElement | null = null;
 let effectsRange: HTMLInputElement | null = null;
 let ambienceRange: HTMLInputElement | null = null;
@@ -28,6 +29,7 @@ export function init(section: HTMLElement): void {
   audioToggle = section.querySelector<HTMLInputElement>('#toggle-audio');
   contrastToggle = section.querySelector<HTMLInputElement>('#toggle-contrast');
   reducedToggle = section.querySelector<HTMLInputElement>('#toggle-reduced');
+  familyToggle = section.querySelector<HTMLInputElement>('#toggle-family-challenge');
   masterRange = section.querySelector<HTMLInputElement>('#range-master');
   effectsRange = section.querySelector<HTMLInputElement>('#range-effects');
   ambienceRange = section.querySelector<HTMLInputElement>('#range-ambience');
@@ -46,6 +48,10 @@ export function init(section: HTMLElement): void {
 
   reducedToggle?.addEventListener('change', () => {
     handlers.onChange?.({ reducedFlash: !!reducedToggle?.checked });
+  });
+
+  familyToggle?.addEventListener('change', () => {
+    handlers.onChange?.({ familyChallengeMode: !!familyToggle?.checked });
   });
 
   effectsRange?.addEventListener('input', () => {
@@ -83,6 +89,7 @@ export function update(options: Options): void {
   audioToggle && (audioToggle.checked = !!options.audioOn);
   contrastToggle && (contrastToggle.checked = !!options.highContrastUI);
   reducedToggle && (reducedToggle.checked = !!options.reducedFlash);
+  familyToggle && (familyToggle.checked = !!options.familyChallengeMode);
   if (masterRange) {
     masterRange.value = String(options.masterVolume ?? 1);
     if (masterValue) masterValue.textContent = `${Math.round((options.masterVolume ?? 1) * 100)}%`;


### PR DESCRIPTION
## Summary
- add a Family Challenge toggle and persisted participant rotation state
- assign each minigame to rotating family members, recording co-op streaks and achievements
- surface challenge leaderboards, MVP highlights, and upcoming caretakers in the summary and farm UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d75a624c5083218a8b37d0711841aa