### PR TITLE
Create cow part asset folder guidance

### DIFF
--- a/src/assets/cowparts/bodies/README.txt
+++ b/src/assets/cowparts/bodies/README.txt
@@ -1,0 +1,14 @@
+Highland Cow Factory – Bodies
+
+Shared sprite rules
+- Canvas size: 512×512 pixels with a fully transparent background.
+- Export sprites as lossless .webp files that preserve alpha.
+- Keep the cow's nose tip aligned to the default anchor at (256,256) unless a recipe overrides it.
+- Maintain consistent line weight, shading, and colour palette across all parts.
+- Use lowercase snake_case names with category prefixes and no spaces.
+
+Category notes
+- Bodies provide the base coat, pose, and silhouette for every cow and must include the full torso, legs, and tail.
+- Anchor reference: body alignment keeps the nose at (256,256); hooves should stay within the canvas bounds.
+- Filename format: body_<coat>_<pose>.webp (for example, body_brown_idle.webp or body_cream_walk.webp).
+- Optional variants can include motion states such as _blink, _walk, or _sit, but keep poses consistent with the manifest.

--- a/src/assets/cowparts/body_acc/README.txt
+++ b/src/assets/cowparts/body_acc/README.txt
@@ -1,0 +1,14 @@
+Highland Cow Factory – Body Accessories
+
+Shared sprite rules
+- Canvas size: 512×512 pixels with a fully transparent background.
+- Export sprites as lossless .webp files that preserve alpha.
+- Keep the cow's nose tip aligned to the default anchor at (256,256) unless a recipe overrides it.
+- Maintain consistent line weight, shading, and colour palette across all parts.
+- Use lowercase snake_case names with category prefixes and no spaces.
+
+Category notes
+- Body accessories include blankets, saddles, backpacks, or satchels that rest on the cow's back.
+- Anchor reference: align straps and blankets so they wrap around the body at approximately (256,300) while leaving legs readable.
+- Filename format: bodyacc_<item>.webp (for example, bodyacc_tartan_blanket.webp, bodyacc_mail_bag.webp).
+- Consider left/right symmetry; asymmetrical props should balance with matching shading across both sides of the cow.

--- a/src/assets/cowparts/faces/README.txt
+++ b/src/assets/cowparts/faces/README.txt
@@ -1,0 +1,14 @@
+Highland Cow Factory – Faces
+
+Shared sprite rules
+- Canvas size: 512×512 pixels with a fully transparent background.
+- Export sprites as lossless .webp files that preserve alpha.
+- Keep the cow's nose tip aligned to the default anchor at (256,256) unless a recipe overrides it.
+- Maintain consistent line weight, shading, and colour palette across all parts.
+- Use lowercase snake_case names with category prefixes and no spaces.
+
+Category notes
+- Faces supply expressions (eyes, muzzle, mouth) and should overlay perfectly on every body variant.
+- Anchor reference: align facial features to the nose at (256,256); eye positions should match the base body guides.
+- Filename format: face_<expression>_<pose>.webp (for example, face_happy_idle.webp or face_sleepy_idle.webp).
+- Provide blink or alternate mouth shapes using the same expression prefix (for example, face_happy_blink.webp).

--- a/src/assets/cowparts/hair/README.txt
+++ b/src/assets/cowparts/hair/README.txt
@@ -1,0 +1,14 @@
+Highland Cow Factory – Hair
+
+Shared sprite rules
+- Canvas size: 512×512 pixels with a fully transparent background.
+- Export sprites as lossless .webp files that preserve alpha.
+- Keep the cow's nose tip aligned to the default anchor at (256,256) unless a recipe overrides it.
+- Maintain consistent line weight, shading, and colour palette across all parts.
+- Use lowercase snake_case names with category prefixes and no spaces.
+
+Category notes
+- Hair sprites cover the fringe/forelock area and should layer between horns and head accessories.
+- Anchor reference: align bangs so the fringe centre sits over (256,180) and follow the face contour.
+- Filename format: hair_<style>.webp (for example, hair_classic.webp, hair_braided.webp, hair_spiky.webp).
+- Provide optional seasonal recolours by appending the colour (hair_classic_ginger.webp) while keeping the base style consistent.

--- a/src/assets/cowparts/head/README.txt
+++ b/src/assets/cowparts/head/README.txt
@@ -1,0 +1,14 @@
+Highland Cow Factory – Head Accessories
+
+Shared sprite rules
+- Canvas size: 512×512 pixels with a fully transparent background.
+- Export sprites as lossless .webp files that preserve alpha.
+- Keep the cow's nose tip aligned to the default anchor at (256,256) unless a recipe overrides it.
+- Maintain consistent line weight, shading, and colour palette across all parts.
+- Use lowercase snake_case names with category prefixes and no spaces.
+
+Category notes
+- Head accessories include crowns, bows, hats, and headbands layered above hair and horns.
+- Anchor reference: align the accessory centre over (256,150) and keep the underside flush with the fringe silhouette.
+- Filename format: acc_<item>.webp (for example, acc_flower_crown.webp, acc_pastel_bow.webp, acc_wizard_hat.webp).
+- Tilted variants should still balance visually and avoid clipping the canvas edges.

--- a/src/assets/cowparts/horns/README.txt
+++ b/src/assets/cowparts/horns/README.txt
@@ -1,0 +1,14 @@
+Highland Cow Factory – Horns
+
+Shared sprite rules
+- Canvas size: 512×512 pixels with a fully transparent background.
+- Export sprites as lossless .webp files that preserve alpha.
+- Keep the cow's nose tip aligned to the default anchor at (256,256) unless a recipe overrides it.
+- Maintain consistent line weight, shading, and colour palette across all parts.
+- Use lowercase snake_case names with category prefixes and no spaces.
+
+Category notes
+- Horn sprites replace the horn shape while respecting the body silhouette and must leave the ears unobstructed.
+- Anchor reference: align the horn base to sit symmetrically around (256,150) so tips clear the canvas edges.
+- Filename format: horns_<style>.webp (for example, horns_default.webp, horns_curled.webp, horns_short.webp).
+- Use smooth curves and subtle shading to match the base bodies; avoid casting shadows on other layers.

--- a/src/assets/cowparts/neck/README.txt
+++ b/src/assets/cowparts/neck/README.txt
@@ -1,0 +1,14 @@
+Highland Cow Factory – Neck Accessories
+
+Shared sprite rules
+- Canvas size: 512×512 pixels with a fully transparent background.
+- Export sprites as lossless .webp files that preserve alpha.
+- Keep the cow's nose tip aligned to the default anchor at (256,256) unless a recipe overrides it.
+- Maintain consistent line weight, shading, and colour palette across all parts.
+- Use lowercase snake_case names with category prefixes and no spaces.
+
+Category notes
+- Neck accessories include scarves, bells, necklaces, or ribbons that wrap around the throat and chest.
+- Anchor reference: position the collar midpoint around (256,320) so it follows the body chest curve.
+- Filename format: neck_<item>.webp (for example, neck_bell.webp, neck_tartan_scarf.webp, neck_ribbon.webp).
+- Ensure accessories stay within canvas bounds and do not cover the muzzle or legs.

--- a/src/assets/cowparts/placeholders/README.txt
+++ b/src/assets/cowparts/placeholders/README.txt
@@ -1,0 +1,14 @@
+Highland Cow Factory – Placeholder Sprites
+
+Shared sprite rules
+- Canvas size: 512×512 pixels with a fully transparent background.
+- Export sprites as lossless .webp files that preserve alpha.
+- Keep the cow's nose tip aligned to the default anchor at (256,256) unless a recipe overrides it.
+- Maintain consistent line weight, shading, and colour palette across all parts.
+- Use lowercase snake_case names with category prefixes and no spaces.
+
+Category notes
+- Placeholder sprites are temporary stand-ins generated from simple vector shapes until production art lands.
+- Anchor reference: mimic the base category anchor when generating each placeholder so layering tests remain accurate.
+- Filename format: placeholder_<category>_<variant>.webp (for example, placeholder_body_idle.webp, placeholder_face_happy.webp).
+- Save assets as base64-encoded .webp data URIs when committing quick prototypes; replace them with final art before launch.

--- a/src/assets/cowparts/themes/space/README.txt
+++ b/src/assets/cowparts/themes/space/README.txt
@@ -1,0 +1,14 @@
+Highland Cow Factory – Space Theme
+
+Shared sprite rules
+- Canvas size: 512×512 pixels with a fully transparent background.
+- Export sprites as lossless .webp files that preserve alpha.
+- Keep the cow's nose tip aligned to the default anchor at (256,256) unless a recipe overrides it.
+- Maintain consistent line weight, shading, and colour palette across all parts.
+- Use lowercase snake_case names with category prefixes and no spaces.
+
+Category notes
+- Space theme parts can cover multiple categories (bodies, faces, accessories) but must stay stylistically cohesive: starfields, nebulae, and futuristic trims.
+- Anchor reference: follow the base category anchors (for example, bodies at (256,256), headgear at (256,150)) so themed items remain compatible with standard parts.
+- Filename format: space_<category>_<variant>.webp (for example, space_body_galaxy.webp, space_head_antenna.webp, space_neck_constellation_cape.webp).
+- Tag each themed entry in sprites.json with the "theme:space" rule so the factory can group matching parts in recipes.


### PR DESCRIPTION
## Summary
- create the cow part asset directories under `src/assets/cowparts`
- add README guidance for each category covering shared sprite rules, anchors, and naming conventions
- document the space theme requirements including tagging parts with `"theme:space"` in the manifest

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d7abd01f5c8321abe1953abe866aa1