### PR TITLE
Add cow factory dev preview page

### DIFF
--- a/highland-cow-farm/src/dev/FactoryTest.ts
+++ b/highland-cow-farm/src/dev/FactoryTest.ts
@@ -1,0 +1,57 @@
+import { CowFactory } from '../game/cowFactory';
+
+async function main(): Promise<void> {
+  const grid = document.querySelector<HTMLDivElement>('[data-factory-grid]');
+  const status = document.querySelector<HTMLElement>('[data-factory-status]');
+
+  if (!grid) {
+    throw new Error('Factory test grid container not found');
+  }
+
+  try {
+    if (status) {
+      status.textContent = 'Loading cow factory…';
+    }
+
+    const factory = new CowFactory();
+    await factory.load();
+
+    const seeds = Array.from({ length: 12 }, (_, index) => `cow-${index}`);
+
+    for (const seed of seeds) {
+      const recipe = await factory.buildRecipe({ seed });
+
+      const figure = document.createElement('figure');
+      figure.className = 'factory-test__item';
+
+      const canvas = document.createElement('canvas');
+      canvas.width = 256;
+      canvas.height = 256;
+      canvas.className = 'factory-test__canvas';
+
+      await factory.renderToCanvas(recipe, canvas);
+
+      canvas.style.width = '256px';
+      canvas.style.height = '256px';
+
+      const caption = document.createElement('figcaption');
+      caption.className = 'factory-test__caption';
+      const partsSummary = recipe.items.map(item => `${item.categoryId}: ${item.partId}`).join('\n');
+      caption.textContent = partsSummary;
+
+      figure.append(canvas, caption);
+      grid.append(figure);
+    }
+
+    if (status) {
+      status.textContent = 'Generated sample cows using deterministic seeds.';
+    }
+  } catch (error) {
+    console.error(error);
+    if (status) {
+      status.textContent = `Failed to load factory test: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  }
+}
+
+void main();

--- a/highland-cow-farm/src/dev/factory-test.html
+++ b/highland-cow-farm/src/dev/factory-test.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cow Factory Test</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+    }
+
+    body {
+      margin: 0;
+      padding: 2rem;
+      background: linear-gradient(180deg, #fefaf4, #f5f0e6);
+      color: #2e1b15;
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+    }
+
+    main {
+      width: min(1200px, 100%);
+    }
+
+    h1 {
+      text-align: center;
+      font-size: clamp(1.75rem, 2vw + 1rem, 2.5rem);
+      margin: 0 0 0.5rem;
+    }
+
+    p[data-factory-status] {
+      margin: 0 0 1.5rem;
+      text-align: center;
+      font-weight: 500;
+    }
+
+    .factory-test__grid {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    .factory-test__item {
+      margin: 0;
+      padding: 1.25rem;
+      background: rgba(255, 255, 255, 0.85);
+      border-radius: 16px;
+      box-shadow: 0 12px 30px rgba(126, 92, 59, 0.15);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+      backdrop-filter: blur(4px);
+    }
+
+    .factory-test__canvas {
+      border-radius: 12px;
+      border: 1px solid rgba(46, 27, 21, 0.1);
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(250, 245, 235, 0.9));
+      width: 256px;
+      height: 256px;
+      image-rendering: crisp-edges;
+    }
+
+    .factory-test__caption {
+      font-size: 0.9rem;
+      line-height: 1.4;
+      white-space: pre-line;
+      text-align: left;
+      width: 100%;
+      color: rgba(46, 27, 21, 0.85);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Cow Factory Visual Test</h1>
+    <p data-factory-status>Preparing cow factory preview…</p>
+    <div class="factory-test__grid" data-factory-grid></div>
+  </main>
+  <script type="module">
+    import './FactoryTest.ts';
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a development script that loads the cow factory, builds deterministic recipes, and renders them to canvases
- create a factory test HTML page with a styled grid to display the rendered cows and their selected parts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7b66a49e48321bf0204743926e694