### PR TITLE
Update asset workflow docs and decode script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,74 @@
 # Highland Cow Farm Adventure
 
-A pastel, slightly-chaotic (Overcooked-style) browser game where you care for a growing herd of adorable Highland cows. Keep them happy, fluffy, and well-fed by juggling fast mini-games and daily farm tasks. Built for offline play in modern browsers.
+A pastel, slightly chaotic farm-sim prototype built around modular Highland cow sprites. This repository contains the in-progress
+game client (a Vite workspace) and the shared asset pipeline for generating cow parts.
 
-## Core Loop (One Game Day)
+## Repository Layout
+- `highland-cow-farm/` – Main Vite project with development tooling and sample factory harness.
+- `src/assets/cowparts/` – Source manifest, placeholder assets, and decoded outputs that power the cow factory.
+- `tools/` – Shared build/decode utilities.
+- `README_COWFACTORY.md` – Deep-dive into the procedural sprite system.
+
+## Development Workflow
+1. `cd highland-cow-farm`
+2. `npm install` – Install local vendored tooling (tsx, vite, TypeScript).
+3. `npm run assets:decode` – Convert any `*.b64` placeholder sprites into real image files before running the app.
+4. `npm run dev:factory` – Launch the Vite dev server focused on the cow factory playground (`src/dev/factory-test.html`).
+
+> Tip: The decode step is fast and can be rerun whenever new parts are added. Existing decoded files are overwritten in place.
+
+## Asset Pipeline
+Cow parts are stored as compact base64 (`.b64`) files under `src/assets/cowparts`. This keeps placeholder art small and easily
+editable (most are inline SVG). The `tools/b64_to_files.ts` script converts those placeholders into regular image files so the
+runtime can load them via URL references. The script now auto-detects whether it should read assets from the shared root
+(`../src/assets/cowparts`) or a local project copy, making it usable from multiple packages.
+
+### Adding a New Cow Part
+Use this checklist whenever you introduce fresh art:
+- [ ] Drop the new asset into `src/assets/cowparts/<category>/placeholders/` as a `.b64` file (or update the decoded version).
+- [ ] Register the part in `src/assets/cowparts/sprites.json`, including tags, poses, coats, and any rules.
+- [ ] Run `npm run assets:decode` to regenerate the decoded files so the factory sees the latest art.
+
+## Appendix: Game Design Snapshot
+The original high-level design goals for the project remain below for reference.
+
+### Core Loop (One Game Day)
 1. **Morning Prep**: New day summary, herd status, unlocked items.
 2. **Task Rush (Timed)**: Cows make requests (food, brushing, chasing, flowers). Player completes mini-games under time pressure.
 3. **Day End**: Scores, happiness changes, unlocks (new cows, accessories, decorations).
 4. **Auto-Save** to `localStorage`.
 
-## Mini-Games (MVP)
-1. **Catch the Cow**  
-   - Several cows try to leave the paddock.  
-   - Click/tap each runaway cow before it reaches the edge.  
+### Mini-Games (MVP)
+1. **Catch the Cow**
+   - Several cows try to leave the paddock.
+   - Click/tap each runaway cow before it reaches the edge.
    - Scales with day number (more/faster cows).
-
-2. **Food Frenzy**  
-   - Cows show a bubble (🥕, 🍎, 🌾, 🪣).  
-   - Drag & drop the correct food quickly.  
+2. **Food Frenzy**
+   - Cows show a bubble (🥕, 🍎, 🌾, 🪣).
+   - Drag & drop the correct food quickly.
    - Overfeeding increases **Chonk** (they get cutely fatter, may move slower next day).
-
-3. **Brush Rush**  
-   - Drag a brush over “messy” patches until clean.  
+3. **Brush Rush**
+   - Drag a brush over “messy” patches until clean.
    - Sparkles appear when fully brushed.
-
-4. *(Planned)* **Flower Fetch**  
+4. *(Planned)* **Flower Fetch**
    - Match flower colours/shapes to cows for bonus happiness.
 
-## Aesthetics & Audio
+### Aesthetics & Audio
 - **Style**: Pastel palette (pink, baby-blue, soft greens), kawaii UI (hearts, stars, sparkles).
 - **Cows**: Big fluffy coats, expressive faces, cute accessories (bows, flower crowns).
 - **SFX**: Soft “moo”, brush swish, munch, gentle “uh-oh” beeps.
 - **Accessibility**: High-contrast UI option, reduced-flash toggle, captions for key SFX cues.
 
-## Progression & Unlocks
+### Progression & Unlocks
 - Start with 2 cows → expand to 20+.
-- Unlocks via milestones:  
-  - **Cows** (new personalities/colours),  
-  - **Accessories** (hats, bows, flower crowns),  
-  - **Decor** (pink barn, rainbow fence),  
+- Unlocks via milestones:
+  - **Cows** (new personalities/colours),
+  - **Accessories** (hats, bows, flower crowns),
+  - **Decor** (pink barn, rainbow fence),
   - **Foods** (cotton candy, ice cream).
 - **Chonk Meter** increases with overfeeding (purely fun; small movement/animation changes only).
 
-## Data Model (v1)
+### Data Model (v1)
 ```ts
 type CowId = string;
 
@@ -76,82 +103,56 @@ interface SaveData {
   };
   lastPlayedISO: string;
 }
-Game States
-BOOT → TITLE → FARM_DAY_START → TASK_RUSH → DAY_SUMMARY → FARM_DAY_START ...
+```
 
-Pausable at any time. Auto-save after DAY_SUMMARY.
+Game States: `BOOT → TITLE → FARM_DAY_START → TASK_RUSH → DAY_SUMMARY → FARM_DAY_START ...`
 
-Tech & Architecture
-Vanilla HTML/CSS/JS (no external libraries; fully offline).
+Pausable at any time. Auto-save after `DAY_SUMMARY`.
 
-Single-file first (index.html with embedded CSS/JS + inline SVG assets).
+### Tech & Architecture
+- Vanilla HTML/CSS/JS (no external libraries; fully offline).
+- Single-file first (index.html with embedded CSS/JS + inline SVG assets).
+- Canvas for mini-games; DOM UI for menus/hub.
+- Timing via `requestAnimationFrame` + deterministic timers (no `setInterval` drift).
+- Persistent state via `localStorage` with versioned schema + migration hook.
 
-Canvas for mini-games; DOM UI for menus/hub.
+### UI / UX Notes
+- Large, tappable buttons; keyboard + mouse + touch friendly.
+- Always show: Day count, Herd size, Happiness average, Time left in task.
+- Pink/pastel theme. Australian English labels.
 
-Timing via requestAnimationFrame + deterministic timers (no setInterval drift).
+### Performance Targets
+- 60 FPS on desktop browsers.
+- Memory leaks avoided (clean up event listeners per state).
+- Canvas layers reused where possible.
 
-Persistent state via localStorage with versioned schema + migration hook.
+### Milestones
+- **M1 (Scaffold & Core)**
+  - Single HTML file, title screen, options, save/load scaffold, farm hub.
+  - Cow model, random name generator, 2 starter cows.
+  - Day cycle loop (empty mini-game stubs).
+- **M2 (Mini-Games MVP)**
+  - Implement Catch the Cow, Food Frenzy, Brush Rush with increasing difficulty.
+  - Day summary screen with scores, happiness deltas, random small unlock.
+- **M3 (Polish & Unlocks)**
+  - Accessories UI (equip bow/flower), basic decor, chonk visuals.
+  - SFX toggles, animations, accessibility options.
+- **M4 (Stretch)**
+  - Flower Fetch mini-game, photo mode, simple achievements.
 
-UI / UX Notes
-Large, tappable buttons; keyboard + mouse + touch friendly.
+### Definition of Done (per feature)
+- Works offline in Chrome/Edge/Firefox (latest).
+- No console errors.
+- State persists across reloads.
+- Responsive layout ≥1024px wide; degrades gracefully on smaller screens.
+- Meets accessibility toggles (high contrast, reduced flash).
 
-Always show: Day count, Herd size, Happiness average, Time left in task.
+### Testing Checklist
+- Start new save → complete a day → reload → state persists.
+- Overfeed a cow → chonk increases → visual reflects next day.
+- Fail a task → happiness reduces → day summary shows change.
+- Toggle audio/contrast → settings persist.
+- Performance stable over 10 consecutive days.
 
-Pink/pastel theme. Australian English labels.
-
-Performance Targets
-60 FPS on desktop browsers.
-
-Memory leaks avoided (clean up event listeners per state).
-
-Canvas layers reused where possible.
-
-Milestones
-M1 (Scaffold & Core)
-
-Single HTML file, title screen, options, save/load scaffold, farm hub.
-
-Cow model, random name generator, 2 starter cows.
-
-Day cycle loop (empty mini-game stubs).
-
-M2 (Mini-Games MVP)
-
-Implement Catch the Cow, Food Frenzy, Brush Rush with increasing difficulty.
-
-Day summary screen with scores, happiness deltas, random small unlock.
-
-M3 (Polish & Unlocks)
-
-Accessories UI (equip bow/flower), basic decor, chonk visuals.
-
-SFX toggles, animations, accessibility options.
-
-M4 (Stretch)
-
-Flower Fetch mini-game, photo mode, simple achievements.
-
-Definition of Done (per feature)
-Works offline in Chrome/Edge/Firefox (latest).
-
-No console errors.
-
-State persists across reloads.
-
-Responsive layout ≥1024px wide; degrades gracefully on smaller screens.
-
-Meets accessibility toggles (high contrast, reduced flash).
-
-Testing Checklist
-Start new save → complete a day → reload → state persists.
-
-Overfeed a cow → chonk increases → visual reflects next day.
-
-Fail a task → happiness reduces → day summary shows change.
-
-Toggle audio/contrast → settings persist.
-
-Performance stable over 10 consecutive days.
-
-Licence
+### Licence
 Personal use.

--- a/highland-cow-farm/tools/b64_to_files.ts
+++ b/highland-cow-farm/tools/b64_to_files.ts
@@ -1,8 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 
-const SOURCE_DIR = path.resolve('src/assets/cowparts');
-
 const MIME_EXTENSION_OVERRIDES: Record<string, string> = {
   'image/svg+xml': '.svg',
   'image/png': '.png',
@@ -17,6 +15,31 @@ const MIME_EXTENSION_OVERRIDES: Record<string, string> = {
   'application/json': '.json',
   'text/plain': '.txt',
 };
+
+async function resolveSourceDir(): Promise<string> {
+  const candidates = [
+    path.resolve('src/assets/cowparts'),
+    path.resolve('../src/assets/cowparts'),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      const stats = await fs.stat(candidate);
+      if (stats.isDirectory()) {
+        return candidate;
+      }
+    } catch (error) {
+      const code = typeof error === 'object' && error && 'code' in error ? (error as { code?: string }).code : undefined;
+      if (code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error(
+    `Unable to find a cowparts directory. Looked in:\n${candidates.map((dir) => ` - ${dir}`).join('\n')}`,
+  );
+}
 
 async function walk(dir: string): Promise<string[]> {
   const entries = await fs.readdir(dir, { withFileTypes: true });
@@ -84,7 +107,8 @@ async function convertFile(filePath: string): Promise<string> {
 }
 
 async function main(): Promise<void> {
-  const b64Files = await walk(SOURCE_DIR);
+  const sourceDir = await resolveSourceDir();
+  const b64Files = await walk(sourceDir);
 
   if (b64Files.length === 0) {
     console.log('No .b64 files found.');

--- a/src/assets/cowparts/placeholders/placeholder_body_acc_saddle.svg
+++ b/src/assets/cowparts/placeholders/placeholder_body_acc_saddle.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'><rect x='32' y='32' width='448' height='448' rx='64' fill='%23E6F5F7'/><text x='256' y='256' text-anchor='middle' dominant-baseline='middle' font-family='Inter, Arial, sans-serif' font-size='48' fill='%23333333'>body_acc_saddle</text></svg>

--- a/src/assets/cowparts/placeholders/placeholder_body_default_idle.svg
+++ b/src/assets/cowparts/placeholders/placeholder_body_default_idle.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'><rect x='32' y='32' width='448' height='448' rx='64' fill='%23F6E0B5'/><text x='256' y='256' text-anchor='middle' dominant-baseline='middle' font-family='Inter, Arial, sans-serif' font-size='48' fill='%23333333'>body_default_idle</text></svg>

--- a/src/assets/cowparts/placeholders/placeholder_face_joyful.svg
+++ b/src/assets/cowparts/placeholders/placeholder_face_joyful.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'><rect x='32' y='32' width='448' height='448' rx='64' fill='%23F7D6E0'/><text x='256' y='256' text-anchor='middle' dominant-baseline='middle' font-family='Inter, Arial, sans-serif' font-size='48' fill='%23333333'>face_joyful</text></svg>

--- a/src/assets/cowparts/placeholders/placeholder_hair_fringed.svg
+++ b/src/assets/cowparts/placeholders/placeholder_hair_fringed.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'><rect x='32' y='32' width='448' height='448' rx='64' fill='%23D8EAF6'/><text x='256' y='256' text-anchor='middle' dominant-baseline='middle' font-family='Inter, Arial, sans-serif' font-size='48' fill='%23333333'>hair_fringed</text></svg>

--- a/src/assets/cowparts/placeholders/placeholder_head_flower_crown.svg
+++ b/src/assets/cowparts/placeholders/placeholder_head_flower_crown.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'><rect x='32' y='32' width='448' height='448' rx='64' fill='%23E0F6EC'/><text x='256' y='256' text-anchor='middle' dominant-baseline='middle' font-family='Inter, Arial, sans-serif' font-size='48' fill='%23333333'>acc_flower_crown</text></svg>

--- a/src/assets/cowparts/placeholders/placeholder_head_pastel_bow.svg
+++ b/src/assets/cowparts/placeholders/placeholder_head_pastel_bow.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'><rect x='32' y='32' width='448' height='448' rx='64' fill='%23F6E6F0'/><text x='256' y='256' text-anchor='middle' dominant-baseline='middle' font-family='Inter, Arial, sans-serif' font-size='48' fill='%23333333'>acc_pastel_bow</text></svg>

--- a/src/assets/cowparts/placeholders/placeholder_horns_default.svg
+++ b/src/assets/cowparts/placeholders/placeholder_horns_default.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'><rect x='32' y='32' width='448' height='448' rx='64' fill='%23E8E0F6'/><text x='256' y='256' text-anchor='middle' dominant-baseline='middle' font-family='Inter, Arial, sans-serif' font-size='48' fill='%23333333'>horns_default</text></svg>

--- a/src/assets/cowparts/placeholders/placeholder_neck_scarf.svg
+++ b/src/assets/cowparts/placeholders/placeholder_neck_scarf.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'><rect x='32' y='32' width='448' height='448' rx='64' fill='%23F6F3D6'/><text x='256' y='256' text-anchor='middle' dominant-baseline='middle' font-family='Inter, Arial, sans-serif' font-size='48' fill='%23333333'>neck_scarf</text></svg>


### PR DESCRIPTION
## Summary
- document the project layout, workflow, and cow part checklist in the root README
- teach the asset decoder to locate shared cowparts assets from either the root or project workspace
- check in the decoded placeholder SVGs produced by the updated pipeline

## Testing
- `npm run assets:decode`
- `npm run dev:factory` *(terminated manually after launch output)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bc49d220832182d54dde1c87ec03